### PR TITLE
fix: chart name and release job

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -64,7 +64,8 @@ jobs:
     permissions:
       contents: read
       packages: write
-    if: github.event.pull_request.merged == true && needs.release-version.outputs.RELEASE_VERSION
+    # this job is disabled because we don't have maven releases yet
+    if: github.event.pull_request.merged == true && needs.release-version.outputs.RELEASE_VERSION && false
     steps:
       - name: Export RELEASE_VERSION env
         run: |

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -140,6 +140,7 @@ maven/mavencentral/org.eclipse.edc/jersey-providers/0.5.2-SNAPSHOT, Apache-2.0, 
 maven/mavencentral/org.eclipse.edc/jetty-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/json-ld-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/json-ld/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/junit-base/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-model/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.5.1, Apache-2.0, approved, technology.edc

--- a/charts/bdrs-server-memory/Chart.yaml
+++ b/charts/bdrs-server-memory/Chart.yaml
@@ -20,8 +20,8 @@
 
 ---
 apiVersion: v2
-name: bdrs-server
-description: A Helm chart for the Tractus-X BPN-DID Resolution Service
+name: bdrs-server-memory
+description: A Helm chart for the Tractus-X BPN-DID Resolution Service (only in-memory persistence)
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/charts/bdrs-server-memory/README.md
+++ b/charts/bdrs-server-memory/README.md
@@ -1,10 +1,13 @@
-# bdrs-server
+# bdrs-server-memory
 
 ![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
-A Helm chart for the Tractus-X BPN-DID Resolution Service
+A Helm chart for the Tractus-X BPN-DID Resolution Service (only in-memory persistence)
 
 **Homepage:** <https://github.com/eclipse-tractusx/bpn-did-resolution-service/tree/main/charts/bdrs-server>
+
+**Please note that this chart only uses in-memory persistence and is therefor not suited for clustered or production deployments.
+Consider the `bdrs-server` chart for production use cases!**
 
 # Configure the chart
 

--- a/charts/bdrs-server-memory/README.md.gotmpl
+++ b/charts/bdrs-server-memory/README.md.gotmpl
@@ -8,6 +8,8 @@
 
 {{ template "chart.homepageLine" . }}
 
+**Please note that this chart only uses in-memory persistence and is therefor not suited for clustered or production deployments.
+Consider the `bdrs-server` chart for production use cases!**
 
 # Configure the chart
 


### PR DESCRIPTION
## WHAT

Updates the chart name of the `-memory` variant, disables the Maven release job for now

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
