### PR TITLE
feat: add ingress example and tests

### DIFF
--- a/.github/actions/run-deployment-test/action.yml
+++ b/.github/actions/run-deployment-test/action.yml
@@ -38,12 +38,12 @@ inputs:
 
   rootDir:
     required: true
-    description: "The directory that contains the docker file, e.g. edc-controlplane/edc-runtime-memory"
+    description: "The directory that contains the docker file"
 
-  values_file:
-    #    required: true
-    required: false
-    description: "A yaml file that contains the values for the test installation. will be modified!"
+  cluster-config:
+    required: true
+    description: "YAML file to contain KinD cluster configuration"
+    default: system-tests/helm/kind.config.yaml
 
 runs:
   using: "composite"
@@ -68,25 +68,30 @@ runs:
 
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.5.0
+      with:
+        config: ${{ inputs.cluster-config }}
 
     - name: Load images into KinD
       shell: bash
       run: |
         kind get clusters | xargs -n1 kind load docker-image ${{ inputs.imagename }}:${{ inputs.image_tag }} --name
 
-    ###################################################
-    # Install the test infrastructure
-    ###################################################
-    #    - name: "Generate test credentials"
-    #      shell: bash
-    #      run: |-
-    #        sh -c "edc-tests/deployment/src/main/resources/prepare-test.sh \
-    #               ${{ inputs.values_file }}"
+    - name: "Install NGINX ingress controller"
+      shell: bash
+      run: |
+        # see: https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx
+        # install NGINX ingress controller
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+        
+        # wait for ingress to become available
+        kubectl wait --namespace ingress-nginx \
+          --for=condition=ready pod \
+          --selector=app.kubernetes.io/component=controller \
+          --timeout=90s
 
     - name: Install Runtime
       shell: bash
       run: ${{ inputs.helm_command }}
-
 
     #################
     ### Tear Down ###

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -67,12 +67,14 @@ jobs:
         with:
           imagename: ${{ matrix.variant.name }}
           rootDir: runtimes/${{ matrix.variant.name }}
+          cluster-config: "system-tests/helm/kind.config.yaml"
           helm_command: |-
             helm install ${{ matrix.variant.name }} ${{ matrix.variant.chart }} \
             --set server.image.pullPolicy="Never" \
             --set server.image.tag="latest" \
             --set server.image.repository="${{ matrix.variant.name }}" \
             --set fullnameOverride="${{ matrix.variant.name }}" \
+            -f system-tests/helm/values-test.yaml \
             --wait-for-jobs --timeout=120s --dependency-update
             
             # wait for the pod to become ready
@@ -80,3 +82,6 @@ jobs:
             
             # execute the helm test
             helm test ${{ matrix.variant.name }}
+
+            # verify ingress is available
+            curl --fail -X GET -k https://localhost/api/directory/bpn-directory -H "content-type: application/json" --output -

--- a/api/directory-api/src/main/java/org/eclipse/tractusx/bdrs/api/directory/DirectoryApiExtension.java
+++ b/api/directory-api/src/main/java/org/eclipse/tractusx/bdrs/api/directory/DirectoryApiExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.tractusx.bdrs.api.directory;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
@@ -30,6 +31,11 @@ import static org.eclipse.tractusx.bdrs.api.directory.DirectoryApiExtension.NAME
 public class DirectoryApiExtension implements ServiceExtension {
     public static final String NAME = "BPN Directory API";
 
+    @Setting(value = "Port for the Directory API", required = true)
+    public static final String MGMT_API_PORT = "web.http.directory.port";
+    @Setting(value = "Path for the Management API", required = true)
+    public static final String MGMT_API_PATH = "web.http.directory.path";
+    static final String CONTEXT_NAME = "directory";
     @Inject
     private DidEntryStore store;
 
@@ -43,7 +49,7 @@ public class DirectoryApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        webService.registerResource(new DirectoryApiController(store));
+        webService.registerResource(CONTEXT_NAME, new DirectoryApiController(store));
     }
 
 }

--- a/api/directory-api/src/test/java/org/eclipse/tractusx/bdrs/api/directory/DirectoryApiExtensionTest.java
+++ b/api/directory-api/src/test/java/org/eclipse/tractusx/bdrs/api/directory/DirectoryApiExtensionTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -34,7 +35,7 @@ class DirectoryApiExtensionTest {
     void verifyBoot(DirectoryApiExtension extension, ServiceExtensionContext context) {
         extension.initialize(context);
 
-        verify(webService).registerResource(isA(DirectoryApiController.class));
+        verify(webService).registerResource(eq("directory"), isA(DirectoryApiController.class));
     }
 
     @BeforeEach

--- a/charts/bdrs-server-memory/README.md
+++ b/charts/bdrs-server-memory/README.md
@@ -75,21 +75,11 @@ helm install my-release tractusx-edc/bdrs-server --version 0.0.2 \
 | server.ingresses[0].certManager.issuer | string | `""` | If preset enables certificate generation via cert-manager namespace scoped issuer |
 | server.ingresses[0].className | string | `""` | Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use |
 | server.ingresses[0].enabled | bool | `false` |  |
-| server.ingresses[0].endpoints | list | `["protocol","public"]` | EDC endpoints exposed by this ingress resource |
+| server.ingresses[0].endpoints | list | `["directory"]` | EDC endpoints exposed by this ingress resource |
 | server.ingresses[0].hostname | string | `"bdrs-server.local"` | The hostname to be used to precisely map incoming traffic onto the underlying network service |
 | server.ingresses[0].tls | object | `{"enabled":false,"secretName":""}` | TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource |
 | server.ingresses[0].tls.enabled | bool | `false` | Enables TLS on the ingress resource |
 | server.ingresses[0].tls.secretName | string | `""` | If present overwrites the default secret name |
-| server.ingresses[1].annotations | object | `{}` | Additional ingress annotations to add |
-| server.ingresses[1].certManager.clusterIssuer | string | `""` | If preset enables certificate generation via cert-manager cluster-wide issuer |
-| server.ingresses[1].certManager.issuer | string | `""` | If preset enables certificate generation via cert-manager namespace scoped issuer |
-| server.ingresses[1].className | string | `""` | Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use |
-| server.ingresses[1].enabled | bool | `false` |  |
-| server.ingresses[1].endpoints | list | `["management","control"]` | EDC endpoints exposed by this ingress resource |
-| server.ingresses[1].hostname | string | `"edc-control.intranet"` | The hostname to be used to precisely map incoming traffic onto the underlying network service |
-| server.ingresses[1].tls | object | `{"enabled":false,"secretName":""}` | TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource |
-| server.ingresses[1].tls.enabled | bool | `false` | Enables TLS on the ingress resource |
-| server.ingresses[1].tls.secretName | string | `""` | If present overwrites the default secret name |
 | server.initContainers | list | `[]` |  |
 | server.limits.cpu | float | `1.5` |  |
 | server.limits.memory | string | `"512Mi"` |  |

--- a/charts/bdrs-server-memory/templates/service.yaml
+++ b/charts/bdrs-server-memory/templates/service.yaml
@@ -40,7 +40,7 @@ spec:
       protocol: TCP
       name: management
     - port: {{ .Values.server.endpoints.directory.port }}
-      targetPort: public
+      targetPort: directory
       protocol: TCP
       name: directory
   selector:

--- a/charts/bdrs-server-memory/values.yaml
+++ b/charts/bdrs-server-memory/values.yaml
@@ -1,6 +1,5 @@
 #################################################################################
-#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.
@@ -19,7 +18,6 @@
 #################################################################################
 
 ---
-# Default values for eclipse-dataspace-connector.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -165,32 +163,7 @@ server:
       annotations: {}
       # -- EDC endpoints exposed by this ingress resource
       endpoints:
-        - protocol
-        - public
-      # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
-      className: ""
-      # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
-      tls:
-        # -- Enables TLS on the ingress resource
-        enabled: false
-        # -- If present overwrites the default secret name
-        secretName: ""
-      ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
-      certManager:
-        # -- If preset enables certificate generation via cert-manager namespace scoped issuer
-        issuer: ""
-        # -- If preset enables certificate generation via cert-manager cluster-wide issuer
-        clusterIssuer: ""
-    ## Private / Intranet facing Ingress
-    - enabled: false
-      # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
-      hostname: "edc-control.intranet"
-      # -- Additional ingress annotations to add
-      annotations: {}
-      # -- EDC endpoints exposed by this ingress resource
-      endpoints:
-        - management
-        - control
+        - directory
       # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
       className: ""
       # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource

--- a/charts/bdrs-server/README.md
+++ b/charts/bdrs-server/README.md
@@ -85,21 +85,11 @@ helm install my-release tractusx-edc/bdrs-server --version 0.0.2 \
 | server.ingresses[0].certManager.issuer | string | `""` | If preset enables certificate generation via cert-manager namespace scoped issuer |
 | server.ingresses[0].className | string | `""` | Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use |
 | server.ingresses[0].enabled | bool | `false` |  |
-| server.ingresses[0].endpoints | list | `["protocol","public"]` | EDC endpoints exposed by this ingress resource |
+| server.ingresses[0].endpoints | list | `["directory"]` | EDC endpoints exposed by this ingress resource |
 | server.ingresses[0].hostname | string | `"bdrs-server.local"` | The hostname to be used to precisely map incoming traffic onto the underlying network service |
 | server.ingresses[0].tls | object | `{"enabled":false,"secretName":""}` | TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource |
 | server.ingresses[0].tls.enabled | bool | `false` | Enables TLS on the ingress resource |
 | server.ingresses[0].tls.secretName | string | `""` | If present overwrites the default secret name |
-| server.ingresses[1].annotations | object | `{}` | Additional ingress annotations to add |
-| server.ingresses[1].certManager.clusterIssuer | string | `""` | If preset enables certificate generation via cert-manager cluster-wide issuer |
-| server.ingresses[1].certManager.issuer | string | `""` | If preset enables certificate generation via cert-manager namespace scoped issuer |
-| server.ingresses[1].className | string | `""` | Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use |
-| server.ingresses[1].enabled | bool | `false` |  |
-| server.ingresses[1].endpoints | list | `["management","control"]` | EDC endpoints exposed by this ingress resource |
-| server.ingresses[1].hostname | string | `"edc-control.intranet"` | The hostname to be used to precisely map incoming traffic onto the underlying network service |
-| server.ingresses[1].tls | object | `{"enabled":false,"secretName":""}` | TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource |
-| server.ingresses[1].tls.enabled | bool | `false` | Enables TLS on the ingress resource |
-| server.ingresses[1].tls.secretName | string | `""` | If present overwrites the default secret name |
 | server.initContainers | list | `[]` |  |
 | server.limits.cpu | float | `1.5` |  |
 | server.limits.memory | string | `"512Mi"` |  |

--- a/charts/bdrs-server/templates/service.yaml
+++ b/charts/bdrs-server/templates/service.yaml
@@ -40,7 +40,7 @@ spec:
       protocol: TCP
       name: management
     - port: {{ .Values.server.endpoints.directory.port }}
-      targetPort: public
+      targetPort: directory
       protocol: TCP
       name: directory
   selector:

--- a/charts/bdrs-server/values.yaml
+++ b/charts/bdrs-server/values.yaml
@@ -1,6 +1,5 @@
 #################################################################################
-#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.
@@ -19,7 +18,6 @@
 #################################################################################
 
 ---
-# Default values for eclipse-dataspace-connector.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -169,32 +167,7 @@ server:
       annotations: {}
       # -- EDC endpoints exposed by this ingress resource
       endpoints:
-        - protocol
-        - public
-      # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
-      className: ""
-      # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
-      tls:
-        # -- Enables TLS on the ingress resource
-        enabled: false
-        # -- If present overwrites the default secret name
-        secretName: ""
-      ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
-      certManager:
-        # -- If preset enables certificate generation via cert-manager namespace scoped issuer
-        issuer: ""
-        # -- If preset enables certificate generation via cert-manager cluster-wide issuer
-        clusterIssuer: ""
-    ## Private / Intranet facing Ingress
-    - enabled: false
-      # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
-      hostname: "edc-control.intranet"
-      # -- Additional ingress annotations to add
-      annotations: {}
-      # -- EDC endpoints exposed by this ingress resource
-      endpoints:
-        - management
-        - control
+        - directory
       # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
       className: ""
       # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource

--- a/system-tests/helm/kind.config.yaml
+++ b/system-tests/helm/kind.config.yaml
@@ -1,0 +1,37 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP

--- a/system-tests/helm/values-test.yaml
+++ b/system-tests/helm/values-test.yaml
@@ -1,0 +1,30 @@
+#################################################################################
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+---
+server:
+  ingresses:
+    - enabled: true
+      hostname: "localhost"
+      endpoints:
+        - directory
+      className: "nginx"
+      tls:
+        enabled: true
+        secretName: "tls-secret"

--- a/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/DirectoryEndToEndTest.java
+++ b/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/DirectoryEndToEndTest.java
@@ -43,6 +43,7 @@ import static org.eclipse.edc.util.io.Ports.getFreePort;
 public class DirectoryEndToEndTest {
     private static final URI API_ENDPOINT = URI.create("http://localhost:" + getFreePort() + "/api");
     private static final URI MANAGEMENT_ENDPOINT = URI.create("http://localhost:" + getFreePort() + "/management/v1");
+    private static final URI DIRECTORY_ENDPOINT = URI.create("http://localhost:" + getFreePort() + "/directory/v1");
     private static final String BPN_DIRECTORY = "bpn-directory";
 
     private static final String AUTH_KEY = "1234";
@@ -62,6 +63,8 @@ public class DirectoryEndToEndTest {
                     Map.of("web.http.port", String.valueOf(API_ENDPOINT.getPort()),
                             "web.http.management.port", String.valueOf(MANAGEMENT_ENDPOINT.getPort()),
                             "web.http.management.path", String.valueOf(MANAGEMENT_ENDPOINT.getPath()),
+                            "web.http.directory.port", String.valueOf(DIRECTORY_ENDPOINT.getPort()),
+                            "web.http.directory.path", String.valueOf(DIRECTORY_ENDPOINT.getPath()),
                             "edc.api.auth.key", AUTH_KEY)
             );
 
@@ -140,7 +143,7 @@ public class DirectoryEndToEndTest {
 
 
     private RequestSpecification apiRequest() {
-        return given().baseUri(API_ENDPOINT.toString())
+        return given().baseUri(DIRECTORY_ENDPOINT.toString())
                 .headers(Map.of());
     }
 


### PR DESCRIPTION
## WHAT

this PR does 3 things:
1. registers the `DirectoryApi` into the `directory` context
2. adds an ingress config (based on NGINX)
3. executes a test in the CI pipeline, that verifies that the directory API is reachable via the ingress

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
