### PR TITLE
feat: add Authorization header validation

### DIFF
--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -83,5 +83,9 @@ jobs:
             # execute the helm test
             helm test ${{ matrix.variant.name }}
 
-            # verify ingress is available
-            curl --fail -X GET -k https://localhost/api/directory/bpn-directory -H "content-type: application/json" --output -
+            # verify ingress is available. expect 401, because we don't have a valid VP/VC (MembershipCred)
+            code=$(curl -X GET -IL -sw "%{http_code}" -k https://localhost/api/directory/bpn-directory -H "content-type: application/json" -o /dev/null)
+            if [ "$code" -ne "401" ]; then
+              echo "BDRS Directory API not ready, status = $code"
+              exit 1;
+            fi

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,3 +1,8 @@
+maven/mavencentral/com.apicatalog/carbon-did/0.0.2, Apache-2.0, approved, #9239
+maven/mavencentral/com.apicatalog/iron-ed25519-cryptosuite-2020/0.8.1, Apache-2.0, approved, #11157
+maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.8.1, Apache-2.0, approved, #9234
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #13683
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.1, Apache-2.0, approved, #7947
@@ -30,14 +35,19 @@ maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.0, Apache-2.0, approve
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
+maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.collections/google-collections/1.0, Apache-2.0, approved, CQ3285
+maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/32.0.1-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.12.3, LGPL-2.1-only AND Apache-2.0 AND LGPL-2.1-or-later AND ANTLR-PD AND LicenseRef-fossology-Non-commercial, approved, #13190
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
@@ -60,6 +70,7 @@ maven/mavencentral/io.rest-assured/json-path/5.4.0, Apache-2.0, approved, #12042
 maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, Apache-2.0, approved, #12039
 maven/mavencentral/io.rest-assured/rest-assured/5.4.0, Apache-2.0, approved, #12040
 maven/mavencentral/io.rest-assured/xml-path/5.4.0, Apache-2.0, approved, #12038
+maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.2.15, Apache-2.0, approved, #11362
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.15, Apache-2.0, approved, #5929
@@ -119,6 +130,9 @@ maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, cle
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.25.1, Apache-2.0, approved, #12585
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
+maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78, MIT, approved, #14235
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14237
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78, MIT, approved, #14238
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.27.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
@@ -135,8 +149,16 @@ maven/mavencentral/org.eclipse.edc/boot-lib/0.6.1-SNAPSHOT, Apache-2.0, approved
 maven/mavencentral/org.eclipse.edc/boot-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/core-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/crypto-common-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-did-core/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-did-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-did-web/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-issuers-configuration/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-service/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-transform/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jersey-core/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jersey-providers-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jetty-core/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -145,17 +167,27 @@ maven/mavencentral/org.eclipse.edc/json-ld-spi/0.6.1-SNAPSHOT, Apache-2.0, appro
 maven/mavencentral/org.eclipse.edc/json-ld/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit-base/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-verifiable-credentials/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/keys-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/keys-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-model/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.5.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/sql-core/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/sql-pool-apache-commons/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/token-core/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/token-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-local/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transform-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transform-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/util-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/validator-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/verifiable-credentials-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/verifiable-credentials/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/web-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api/2.0.0, EPL-2.0 OR Apache-2.0, approved, rt.jetty

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -211,8 +211,8 @@ maven/mavencentral/org.eclipse.jetty/jetty-servlet/11.0.20, EPL-2.0 OR Apache-2.
 maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.20, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.20, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.20, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.flywaydb/flyway-core/10.10.0, Apache-2.0, approved, #14163
-maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.10.0, Apache-2.0, approved, #14158
+maven/mavencentral/org.flywaydb/flyway-core/10.11.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.11.0, Apache-2.0, approved, #14239
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish

--- a/api/authentication/build.gradle.kts
+++ b/api/authentication/build.gradle.kts
@@ -1,0 +1,57 @@
+/*
+ *
+ *   Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ *   See the NOTICE file(s) distributed with this work for additional
+ *   information regarding copyright ownership.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Apache License, Version 2.0 which is available at
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+plugins {
+    `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
+}
+
+dependencies {
+    implementation(project(":spi:core-spi"))
+    implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.web)
+    implementation(libs.edc.spi.auth)
+    implementation(libs.edc.spi.did)
+    implementation(libs.edc.spi.identitytrust)
+    implementation(libs.edc.spi.token)
+    implementation(libs.edc.spi.vc)
+
+    implementation(libs.edc.lib.keys)
+    implementation(libs.edc.vc.jwt) // JwtPresentationVerifier
+    implementation(libs.edc.vc) // VerifiableCredentialValidationService
+    implementation(libs.edc.identitytrust.service) //MultiFormatPresentationVerifier
+    implementation(libs.edc.identitytrust.transform) //JwtToVerifiablePresentationTransformer
+    implementation(libs.edc.lib.transform)
+    implementation(libs.edc.lib.jsonld)
+    implementation(libs.edc.lib.http)
+
+    implementation(libs.nimbus.jwt)
+
+    testImplementation(libs.restAssured)
+    testImplementation(testFixtures(libs.edc.core.jersey))
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("directory-api")
+    }
+}
+

--- a/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationExtension.java
+++ b/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationExtension.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.bdrs.api.directory.authentication;
+
+import dev.failsafe.RetryPolicy;
+import okhttp3.OkHttpClient;
+import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
+import org.eclipse.edc.http.client.EdcHttpClientImpl;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
+import org.eclipse.edc.iam.identitytrust.service.verification.MultiFormatPresentationVerifier;
+import org.eclipse.edc.iam.identitytrust.transform.to.JwtToVerifiableCredentialTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JwtToVerifiablePresentationTransformer;
+import org.eclipse.edc.iam.verifiablecredentials.StatusList2021RevocationService;
+import org.eclipse.edc.iam.verifiablecredentials.VerifiableCredentialValidationServiceImpl;
+import org.eclipse.edc.iam.verifiablecredentials.spi.validation.TrustedIssuerRegistry;
+import org.eclipse.edc.jsonld.JsonLdConfiguration;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
+import org.eclipse.edc.token.spi.TokenValidationService;
+import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.verifiablecredentials.jwt.JwtPresentationVerifier;
+import org.eclipse.edc.web.spi.WebService;
+
+import java.time.Clock;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+import static org.eclipse.tractusx.bdrs.api.directory.authentication.CredentialBasedAuthenticationExtension.NAME;
+
+/**
+ * Registers an authentication service that checks MembershipCredentials.
+ */
+@Extension(NAME)
+public class CredentialBasedAuthenticationExtension implements ServiceExtension {
+    public static final long DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS = 15 * 60 * 1000L;
+    @Setting(value = "Validity period of cached StatusList2021 credential entries in milliseconds.", defaultValue = DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS + "", type = "long")
+    public static final String REVOCATION_CACHE_VALIDITY = "edc.iam.credential.revocation.cache.validity";
+    public static final String NAME = "Directory API Authentication Extension";
+    public static final String MONITOR_PREFIX = "Presentation Transformation";
+    private static final String DIRECTORY_CONTEXT = "directory";
+    @Inject
+    private WebService webService;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private TokenValidationService tokenValidationService;
+    @Inject
+    private TokenValidationRulesRegistry rulesRegistry;
+    @Inject
+    private DidPublicKeyResolver didPublicKeyResolver;
+    @Inject
+    private Clock clock;
+
+    private TrustedIssuerRegistry trustedIssuerRegistry;
+    private TypeTransformerRegistryImpl typeTransformerRegistry;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var mapper = typeManager.getMapper(JSON_LD);
+        // the DidPublicKeyResolver has a dependency onto the KeyParserRegistry, so that must be created in a separate ext -> KeyParserRegistryExtension
+        var jwtVerifier = new JwtPresentationVerifier(mapper, tokenValidationService, rulesRegistry, didPublicKeyResolver);
+        var presentationVerifier = new MultiFormatPresentationVerifier(null, jwtVerifier);
+
+        var validity = context.getConfig().getLong(REVOCATION_CACHE_VALIDITY, DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS);
+        var statuslistService = new StatusList2021RevocationService(typeManager.getMapper(), validity);
+        var validationService = new VerifiableCredentialValidationServiceImpl(presentationVerifier, createTrustedIssuerRegistry(), statuslistService, clock);
+
+        webService.registerResource(DIRECTORY_CONTEXT, new AuthenticationRequestFilter(new CredentialBasedAuthenticationService(context.getMonitor(), typeManager.getMapper(), validationService, typeTransformerRegistry(context))));
+    }
+
+    // must provide this, so the TrustedIssuerRegistryConfigurationExtension can inject it
+    @Provider
+    public TrustedIssuerRegistry createTrustedIssuerRegistry() {
+        if (trustedIssuerRegistry == null) {
+            trustedIssuerRegistry = new TrustedIssuerRegistryImpl();
+        }
+        return trustedIssuerRegistry;
+    }
+
+    @Provider
+    public TypeTransformerRegistry typeTransformerRegistry(ServiceExtensionContext context) {
+        if (typeTransformerRegistry == null) {
+            typeTransformerRegistry = new TypeTransformerRegistryImpl();
+            var monitor = context.getMonitor().withPrefix(MONITOR_PREFIX);
+            typeTransformerRegistry.register(new JwtToVerifiablePresentationTransformer(monitor, typeManager.getMapper(JSON_LD), new TitaniumJsonLd(monitor, JsonLdConfiguration.Builder.newInstance().build())));
+            typeTransformerRegistry.register(new JwtToVerifiableCredentialTransformer(monitor));
+        }
+        return typeTransformerRegistry;
+    }
+
+    @Provider
+    public EdcHttpClient httpClient(ServiceExtensionContext context) {
+        return new EdcHttpClientImpl(new OkHttpClient(), RetryPolicy.ofDefaults(), context.getMonitor().withPrefix(MONITOR_PREFIX));
+    }
+}

--- a/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationService.java
+++ b/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationService.java
@@ -77,8 +77,9 @@ public class CredentialBasedAuthenticationService implements AuthenticationServi
      */
     private boolean isValidJwt(String token) {
         var parts = token.split("\\.");
-        if (parts.length != 3) // The JWT is composed of three parts
+        if (parts.length != 3) { // The JWT is composed of three parts
             return false;
+        }
         var decoder = Base64.getUrlDecoder();
         return canParse(decoder.decode(parts[0])) && canParse(decoder.decode(parts[1]));
     }

--- a/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationService.java
+++ b/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationService.java
@@ -1,0 +1,97 @@
+package org.eclipse.tractusx.bdrs.api.directory.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.api.auth.spi.AuthenticationService;
+import org.eclipse.edc.iam.verifiablecredentials.spi.VerifiableCredentialValidationService;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiablePresentation;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiablePresentationContainer;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.exception.AuthenticationFailedException;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+/**
+ * AuthenticationService that takes a "Bearer" token from the "Authorization" header, and
+ * checks whether that token is a valid VerifiablePresentation, and contains a valid MembershipCredential.
+ */
+public class CredentialBasedAuthenticationService implements AuthenticationService {
+    private final Monitor monitor;
+    private final ObjectMapper objectMapper;
+    private final VerifiableCredentialValidationService verifiableCredentialValidationService;
+    private final TypeTransformerRegistry typeTransformerRegistry;
+
+    public CredentialBasedAuthenticationService(Monitor monitor, ObjectMapper objectMapper, VerifiableCredentialValidationService verifiableCredentialValidationService, TypeTransformerRegistry typeTransformerRegistry) {
+        this.monitor = monitor;
+        this.objectMapper = objectMapper;
+        this.verifiableCredentialValidationService = verifiableCredentialValidationService;
+        this.typeTransformerRegistry = typeTransformerRegistry;
+    }
+
+    @Override
+    public boolean isAuthenticated(Map<String, List<String>> headers) {
+
+        if (headers == null || headers.isEmpty()) {
+            throw new AuthenticationFailedException("Headers were null or empty");
+        }
+        Objects.requireNonNull(headers, "headers");
+
+        var authHeaders = headers.keySet().stream()
+                .filter(k -> k.equalsIgnoreCase(AUTHORIZATION))
+                .map(headers::get)
+                .findFirst();
+
+        return authHeaders.map(this::performCredentialValidation).orElseThrow(() -> new AuthenticationFailedException("Header '%s' not present".formatted(AUTHORIZATION)));
+    }
+
+    private boolean performCredentialValidation(List<String> authHeaders) {
+        if (authHeaders.size() != 1) {
+            return false;
+        }
+        var token = authHeaders.get(0);
+        if (!token.toLowerCase().startsWith("bearer ")) {
+            return false;
+        }
+        token = token.substring(6).trim(); // "bearer" has 7 characters, it could be upper case, lower case or capitalized
+
+        if (!isValidJwt(token)) {
+            return false;
+        }
+
+        var finalToken = token;
+        return typeTransformerRegistry.transform(token, VerifiablePresentation.class)
+                .compose(pres -> verifiableCredentialValidationService.validate(List.of(new VerifiablePresentationContainer(finalToken, CredentialFormat.JWT, pres)), new MustHaveMemberhipCredentialRule()))
+                .onFailure(f -> monitor.warning("Error validating BDRS client VP: %s".formatted(f.getFailureDetail())))
+                .succeeded();
+    }
+
+    /**
+     * checks if a string is a valid JWT by splitting it on ".", and checking that the first two parts are valid JSON
+     */
+    private boolean isValidJwt(String token) {
+        var parts = token.split("\\.");
+        if (parts.length != 3) // The JWT is composed of three parts
+            return false;
+        var decoder = Base64.getUrlDecoder();
+        return canParse(decoder.decode(parts[0])) && canParse(decoder.decode(parts[1]));
+    }
+
+    /**
+     * checks if a string is valid JSON
+     */
+    private boolean canParse(byte[] rawInput) {
+        try (var parser = objectMapper.createParser(rawInput)) {
+            parser.nextToken();
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/KeyParserRegistryExtension.java
+++ b/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/KeyParserRegistryExtension.java
@@ -1,0 +1,30 @@
+package org.eclipse.tractusx.bdrs.api.directory.authentication;
+
+import org.eclipse.edc.keys.KeyParserRegistryImpl;
+import org.eclipse.edc.keys.keyparsers.JwkParser;
+import org.eclipse.edc.keys.keyparsers.PemParser;
+import org.eclipse.edc.keys.spi.KeyParserRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+
+/**
+ * This extension must be separate from the {@link CredentialBasedAuthenticationExtension} to avoid a cyclic dependency
+ */
+@Extension(value = "Provides a KeyParserRegistry")
+public class KeyParserRegistryExtension implements ServiceExtension {
+    @Inject
+    private TypeManager typeManager;
+
+    @Provider
+    public KeyParserRegistry keyParserRegistry(ServiceExtensionContext context) {
+        var keyParserRegistry = new KeyParserRegistryImpl();
+        var monitor = context.getMonitor().withPrefix("PrivateKeyResolution");
+        keyParserRegistry.register(new JwkParser(typeManager.getMapper(), monitor));
+        keyParserRegistry.register(new PemParser(monitor));
+        return keyParserRegistry;
+    }
+}

--- a/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/MustHaveMemberhipCredentialRule.java
+++ b/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/MustHaveMemberhipCredentialRule.java
@@ -1,0 +1,14 @@
+package org.eclipse.tractusx.bdrs.api.directory.authentication;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
+import org.eclipse.edc.iam.verifiablecredentials.spi.validation.CredentialValidationRule;
+import org.eclipse.edc.spi.result.Result;
+
+public class MustHaveMemberhipCredentialRule implements CredentialValidationRule {
+    private static final String MEMBERSHIP_TYPE = "MembershipCredential";
+
+    @Override
+    public Result<Void> apply(VerifiableCredential verifiableCredential) {
+        return verifiableCredential.getType().contains(MEMBERSHIP_TYPE) ? Result.success() : Result.failure("Expected only credentials containing type '%s', but got '%s'.".formatted(MEMBERSHIP_TYPE, verifiableCredential.getType()));
+    }
+}

--- a/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/TrustedIssuerRegistryImpl.java
+++ b/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/TrustedIssuerRegistryImpl.java
@@ -1,0 +1,27 @@
+package org.eclipse.tractusx.bdrs.api.directory.authentication;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
+import org.eclipse.edc.iam.verifiablecredentials.spi.validation.TrustedIssuerRegistry;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TrustedIssuerRegistryImpl implements TrustedIssuerRegistry {
+    private final Map<String, Issuer> store = new HashMap<>();
+
+    @Override
+    public void addIssuer(Issuer issuer) {
+        store.put(issuer.id(), issuer);
+    }
+
+    @Override
+    public Issuer getById(String id) {
+        return store.get(id);
+    }
+
+    @Override
+    public Collection<Issuer> getTrustedIssuers() {
+        return store.values();
+    }
+}

--- a/api/authentication/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/api/authentication/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,22 @@
+#
+#
+#   Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+#
+#   See the NOTICE file(s) distributed with this work for additional
+#   information regarding copyright ownership.
+#
+#   This program and the accompanying materials are made available under the
+#   terms of the Apache License, Version 2.0 which is available at
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+#   SPDX-License-Identifier: Apache-2.0
+#
+#
+org.eclipse.tractusx.bdrs.api.directory.authentication.CredentialBasedAuthenticationExtension
+org.eclipse.tractusx.bdrs.api.directory.authentication.KeyParserRegistryExtension

--- a/api/authentication/src/test/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationServiceTest.java
+++ b/api/authentication/src/test/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationServiceTest.java
@@ -1,0 +1,76 @@
+package org.eclipse.tractusx.bdrs.api.directory.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.iam.verifiablecredentials.spi.VerifiableCredentialValidationService;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiablePresentation;
+import org.eclipse.edc.iam.verifiablecredentials.spi.validation.CredentialValidationRule;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.exception.AuthenticationFailedException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CredentialBasedAuthenticationServiceTest {
+
+
+    private final Monitor monitor = mock();
+    private final VerifiableCredentialValidationService validationService = mock();
+    private final TypeTransformerRegistry typeTransformerRegistry = mock();
+    private final CredentialBasedAuthenticationService service = new CredentialBasedAuthenticationService(monitor, new ObjectMapper(), validationService, typeTransformerRegistry);
+
+    @Test
+    void isAuthenticated_noHeader() {
+        assertThatThrownBy(() -> service.isAuthenticated(null)).isInstanceOf(AuthenticationFailedException.class);
+        assertThatThrownBy(() -> service.isAuthenticated(Map.of())).isInstanceOf(AuthenticationFailedException.class);
+    }
+
+    @Test
+    void isAuthenticated_noAuthHeader() {
+        assertThatThrownBy(() -> service.isAuthenticated(Map.of("foo", List.of("bar")))).isInstanceOf(AuthenticationFailedException.class);
+    }
+
+    @Test
+    void isAuthenticated_multipleAuthHeaders() {
+        assertThat(service.isAuthenticated(Map.of("Authorization", List.of("foo", "bar", "baz")))).isFalse();
+    }
+
+    @Test
+    void isAuthenticated_notBearer() {
+        assertThat(service.isAuthenticated(Map.of("Authorization", List.of("value")))).isFalse();
+    }
+
+    @Test
+    void isAuthenticated_tokenNotJwtFormat() {
+        assertThat(service.isAuthenticated(Map.of("Authorization", List.of("Bearer value")))).isFalse();
+    }
+
+    @Test
+    void isAuthenticated_vpInvalid() {
+        when(validationService.validate(anyList(), any(CredentialValidationRule[].class)))
+                .thenReturn(Result.failure("test failure"));
+        when(typeTransformerRegistry.transform(any(), eq(VerifiablePresentation.class)))
+                .thenReturn(Result.success(VerifiablePresentation.Builder.newInstance().type("VerifiablePresentation").build()));
+
+        assertThat(service.isAuthenticated(Map.of("Authorization", List.of("Bearer " + createSerializedJwt())))).isFalse();
+        verify(monitor).warning(startsWith("Error validating BDRS client VP"));
+    }
+
+    private String createSerializedJwt() {
+        return "eyJhbGciOiJIUzI1NiIsI" +
+                "nR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwi" +
+                "aWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,8 @@ subprojects {
                     from("${projectDir}/notice.md")
 
                 }
-                dependsOn(tasks.named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME))
+                mustRunAfter(tasks.named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME))
+                mustRunAfter(tasks.named(JavaPlugin.JAR_TASK_NAME))
             }
 
             //actually apply the plugin to the (sub-)project

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,15 +14,25 @@ flyway = "10.10.0"
 [libraries]
 edc-core-jetty = { module = "org.eclipse.edc:jetty-core", version.ref = "edc" }
 edc-core-jersey = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
+edc-core-did = { module = "org.eclipse.edc:identity-did-core", version.ref = "edc" }
 
 edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
+edc-vc-jwt = { module = "org.eclipse.edc:jwt-verifiable-credentials", version.ref = "edc" }
+edc-vc = { module = "org.eclipse.edc:verifiable-credentials", version.ref = "edc" }
+edc-identitytrust-service = { module = "org.eclipse.edc:identity-trust-service", version.ref = "edc" }
+edc-identitytrust-issuers = { module = "org.eclipse.edc:identity-trust-issuers-configuration", version.ref = "edc" }
+edc-identitytrust-transform = { module = "org.eclipse.edc:identity-trust-transform", version.ref = "edc" }
+edc-identitydidweb = { module = "org.eclipse.edc:identity-did-web", version.ref = "edc" }
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
+edc-spi-did = { module = "org.eclipse.edc:identity-did-spi", version.ref = "edc" }
 edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 edc-spi-transaction = { module = "org.eclipse.edc:transaction-spi", version.ref = "edc" }
 edc-spi-transaction-datasource = { module = "org.eclipse.edc:transaction-datasource-spi", version.ref = "edc" }
 edc-connector-core = { module = "org.eclipse.edc:connector-core", version.ref = "edc" }
-#edc-spi-identity-trust = { module = "org.eclipse.edc:identity-trust-spi", version.ref = "edc" }
 edc-spi-jwt = { module = "org.eclipse.edc:jwt-spi", version.ref = "edc" }
+edc-spi-token = { module = "org.eclipse.edc:token-spi", version.ref = "edc" }
+edc-spi-identitytrust = { module = "org.eclipse.edc:identity-trust-spi", version.ref = "edc" }
+edc-spi-vc = { module = "org.eclipse.edc:verifiable-credentials-spi", version.ref = "edc" }
 edc-spi-auth = { module = "org.eclipse.edc:auth-spi", version.ref = "edc" }
 edc-auth-tokenbased = { module = "org.eclipse.edc:auth-tokenbased", version.ref = "edc" }
 edc-vault-filesystem = { module = "org.eclipse.edc:vault-filesystem", version.ref = "edc" }
@@ -31,6 +41,11 @@ edc-api-observability = { module = "org.eclipse.edc:api-observability", version.
 edc-core-sql = { module = "org.eclipse.edc:sql-core", version.ref = "edc" }
 edc-transaction-local = { module = "org.eclipse.edc:transaction-local", version.ref = "edc" }
 edc-sql-pool = { module = "org.eclipse.edc:sql-pool-apache-commons", version.ref = "edc" }
+
+edc-lib-keys = { module = "org.eclipse.edc:keys-lib", version.ref = "edc" }
+edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "edc" }
+edc-lib-jsonld = { module = "org.eclipse.edc:json-ld-lib", version.ref = "edc" }
+edc-lib-http = { module = "org.eclipse.edc:http-lib", version.ref = "edc" }
 
 # Third party libs
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
@@ -48,9 +63,9 @@ shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 [bundles]
 # TODO: "edc-vault-filesystem" - remove dependency on org.eclipse.edc.vault.filesystem.JskPrivateKeyResolverExtension
 bdrs-boot = [
-  "edc-core-jetty",
-  "edc-core-jersey",
-  "edc-boot",
-  "edc-spi-auth",
-  "edc-auth-tokenbased",
+    "edc-core-jetty",
+    "edc-core-jersey",
+    "edc-boot",
+    "edc-spi-auth",
+    "edc-auth-tokenbased",
 ]

--- a/runtimes/bdrs-server-memory/build.gradle.kts
+++ b/runtimes/bdrs-server-memory/build.gradle.kts
@@ -27,10 +27,14 @@ plugins {
 dependencies {
     runtimeOnly(libs.bundles.bdrs.boot)
     runtimeOnly(libs.edc.api.observability)
+    runtimeOnly(libs.edc.core.did)
+    runtimeOnly(libs.edc.identitydidweb)
+    runtimeOnly(libs.edc.identitytrust.issuers)
 
     runtimeOnly(project(":core:core-services"))
     runtimeOnly(project(":api:directory-api"))
     runtimeOnly(project(":api:management-api"))
+    runtimeOnly(project(":api:authentication"))
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/runtimes/bdrs-server/build.gradle.kts
+++ b/runtimes/bdrs-server/build.gradle.kts
@@ -25,16 +25,12 @@ plugins {
 }
 
 dependencies {
-    runtimeOnly(libs.bundles.bdrs.boot)
-    runtimeOnly(libs.edc.api.observability)
+    runtimeOnly(project(":runtimes:bdrs-server-memory"))
     runtimeOnly(libs.edc.transaction.local)
     runtimeOnly(libs.edc.sql.pool)
     runtimeOnly(libs.postgres)
 
-    runtimeOnly(project(":core:core-services"))
     runtimeOnly(project(":extensions:store:sql:did-entry-store-sql"))
-    runtimeOnly(project(":api:directory-api"))
-    runtimeOnly(project(":api:management-api"))
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,6 +48,7 @@ include(":spi:core-spi")
 include(":core:core-services")
 include(":api:directory-api")
 include(":api:management-api")
+include(":api:authentication")
 include(":runtimes:bdrs-server")
 include(":runtimes:bdrs-server-memory")
 

--- a/system-tests/test-directory/build.gradle.kts
+++ b/system-tests/test-directory/build.gradle.kts
@@ -20,5 +20,10 @@ dependencies {
     testImplementation(libs.edc.junit)
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.restAssured)
+    testImplementation(libs.edc.spi.web)
+    testImplementation(libs.edc.spi.did)
+
+    testImplementation(testFixtures(libs.edc.vc.jwt)) // JwtCreationUtils
+    testImplementation(libs.nimbus.jwt)
 }
 

--- a/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/DirectoryEndToEndTest.java
+++ b/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/DirectoryEndToEndTest.java
@@ -67,7 +67,9 @@ public class DirectoryEndToEndTest {
     private static final String BPN_DIRECTORY = "bpn-directory";
 
     private static final String AUTH_KEY = "1234";
-    final @RegisterExtension
+    private static final String BPN1 = "BPN12345";
+    private static final String DID1 = "did:web:localhost/foo";
+    @RegisterExtension
     protected static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
             ":system-tests:test-server",
             "BDRS Server",
@@ -79,10 +81,6 @@ public class DirectoryEndToEndTest {
                     "edc.iam.trusted-issuer.test.id", "did:web:some-issuer",
                     "edc.api.auth.key", AUTH_KEY)
     );
-    private static final String BPN1 = "BPN12345";
-    private static final String DID1 = "did:web:localhost/foo";
-
-
     private final String issuerId = "did:web:some-issuer";
     private final String holderId = "did:web:bdrs-client";
     private ECKey vcIssuerKey;

--- a/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/DirectoryEndToEndTest.java
+++ b/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/DirectoryEndToEndTest.java
@@ -14,18 +14,36 @@
 
 package org.eclipse.tractusx.bdrs.test.directory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolver;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.verifiablecredentials.jwt.JwtCreationUtils;
+import org.eclipse.edc.web.spi.ApiErrorDetail;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
 import static io.restassured.RestAssured.config;
@@ -34,7 +52,9 @@ import static io.restassured.config.DecoderConfig.ContentDecoder.DEFLATE;
 import static io.restassured.config.DecoderConfig.decoderConfig;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.result.Result.success;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.eclipse.tractusx.bdrs.test.directory.TestData.VP_CONTENT_EXAMPLE;
 
 /**
  * Performs end-to-end testing of the BPN Directory.
@@ -47,76 +67,209 @@ public class DirectoryEndToEndTest {
     private static final String BPN_DIRECTORY = "bpn-directory";
 
     private static final String AUTH_KEY = "1234";
-
+    final @RegisterExtension
+    protected static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
+            ":system-tests:test-server",
+            "BDRS Server",
+            Map.of("web.http.port", String.valueOf(API_ENDPOINT.getPort()),
+                    "web.http.management.port", String.valueOf(MANAGEMENT_ENDPOINT.getPort()),
+                    "web.http.management.path", String.valueOf(MANAGEMENT_ENDPOINT.getPath()),
+                    "web.http.directory.port", String.valueOf(DIRECTORY_ENDPOINT.getPort()),
+                    "web.http.directory.path", String.valueOf(DIRECTORY_ENDPOINT.getPath()),
+                    "edc.iam.trusted-issuer.test.id", "did:web:some-issuer",
+                    "edc.api.auth.key", AUTH_KEY)
+    );
     private static final String BPN1 = "BPN12345";
     private static final String DID1 = "did:web:localhost/foo";
 
-    private static final String BPN2 = "BPN67890";
-    private static final String DID2 = "did:web:localhost/bar";
-    private static final String UPDATED_DID2 = "did:web:localhost/baz";
 
-    @RegisterExtension
-    protected static EdcRuntimeExtension runtime =
-            new EdcRuntimeExtension(
-                    ":system-tests:test-server",
-                    "bdrs",
-                    Map.of("web.http.port", String.valueOf(API_ENDPOINT.getPort()),
-                            "web.http.management.port", String.valueOf(MANAGEMENT_ENDPOINT.getPort()),
-                            "web.http.management.path", String.valueOf(MANAGEMENT_ENDPOINT.getPath()),
-                            "web.http.directory.port", String.valueOf(DIRECTORY_ENDPOINT.getPort()),
-                            "web.http.directory.path", String.valueOf(DIRECTORY_ENDPOINT.getPath()),
-                            "edc.api.auth.key", AUTH_KEY)
-            );
-
+    private final String issuerId = "did:web:some-issuer";
+    private final String holderId = "did:web:bdrs-client";
+    private ECKey vcIssuerKey;
+    private ECKey vpHolderKey;
     private ObjectMapper mapper;
 
-    @Test
-    void verifyPublicBpnDirectoryRequest() throws IOException {
-        seedServer(BPN1, DID1);
-        var result = getBpnDirectory(apiRequest());
-        assertThat(result.get(BPN1)).isEqualTo(DID1);
-    }
-
-    @Test
-    void verifyManagementApi() throws IOException {
-        seedServer(BPN1, DID1);
-        seedServer(BPN2, DID2);
-
-        // verify BPNs are returned
-        var result = getBpnDirectory(managementRequest());
-
-        assertThat(result.get(BPN1)).isEqualTo(DID1);
-        assertThat(result.get(BPN2)).isEqualTo(DID2);
-
-        // verify delete
-        managementRequest()
-                .when()
-                .delete(BPN_DIRECTORY + "/" + BPN1)
-                .then()
-                .statusCode(204);
-
-        result = getBpnDirectory(managementRequest());
-
-        assertThat(result.get(BPN1)).isNull();
-        assertThat(result.get(BPN2)).isEqualTo(DID2);
-
-        // verify update
-        var content = Map.of("bpn", BPN2, "did", UPDATED_DID2);
-        managementRequest()
-                .body(content)
-                .when()
-                .put(BPN_DIRECTORY)
-                .then()
-                .statusCode(204);
-
-        result = getBpnDirectory(managementRequest());
-
-        assertThat(result.get(BPN2)).isEqualTo(UPDATED_DID2);
-    }
-
     @BeforeEach
-    void setUp() {
+    void setUp() throws JOSEException {
         mapper = new ObjectMapper();
+        vcIssuerKey = new ECKeyGenerator(Curve.P_256).keyID(issuerId + "#key-1").generate();
+        vpHolderKey = new ECKeyGenerator(Curve.P_256).keyID(holderId + "#key-1").generate();
+    }
+
+    @DisplayName("Reject a request without Authorization header")
+    @Test
+    void getDirectory_missingAuthHeader() throws IOException {
+        seedServer(BPN1, DID1);
+        var errors = getBpnDirectory(apiRequest()).statusCode(401)
+                .extract()
+                .body()
+                .as(ApiErrorDetail[].class);
+
+        assertThat(errors.length).isEqualTo(1);
+        assertThat(errors[0].getType()).isEqualTo("AuthenticationFailed");
+        assertThat(errors[0].getMessage()).isEqualTo("Header 'Authorization' not present");
+    }
+
+    @DisplayName("Reject an Authorization header that does not start with \"Bearer\"")
+    @Test
+    void getDirectory_authHeaderNoBearer() throws IOException {
+        seedServer(BPN1, DID1);
+        var errors = getBpnDirectory(apiRequest().header("Authorization", "foobar")).statusCode(401)
+                .extract()
+                .body()
+                .as(ApiErrorDetail[].class);
+
+        assertThat(errors.length).isEqualTo(1);
+        assertThat(errors[0].getType()).isEqualTo("AuthenticationFailed");
+        assertThat(errors[0].getMessage()).isEqualTo("Request could not be authenticated");
+    }
+
+    @DisplayName("Reject an Authorization header that is not in JWT format")
+    @Test
+    void getDirectory_authHeaderNotJwt() throws IOException {
+        seedServer(BPN1, DID1);
+        var errors = getBpnDirectory(apiRequest().header("Authorization", "Bearer foobar")).statusCode(401)
+                .extract()
+                .body()
+                .as(ApiErrorDetail[].class);
+
+        assertThat(errors.length).isEqualTo(1);
+        assertThat(errors[0].getType()).isEqualTo("AuthenticationFailed");
+        assertThat(errors[0].getMessage()).isEqualTo("Request could not be authenticated");
+    }
+
+    @DisplayName("Accept a valid VP containing a valid MembershipCredential")
+    @Test
+    void getDirectory_validPresentation() throws IOException {
+        registerDids();
+
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcIssuerKey, issuerId, "degreeSub", holderId, Map.of("vc", asMap(TestData.MEMBERSHIP_CREDENTIAL.formatted(holderId))));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpHolderKey, holderId, null, "bdrs-server-audience", Map.of("vp", asMap(VP_CONTENT_EXAMPLE.formatted(holderId, "\"" + vcJwt1 + "\""))));
+
+        seedServer(BPN1, DID1);
+        var bytes = getBpnDirectory(apiRequest().header("Authorization", "Bearer " + vpJwt))
+                .statusCode(200)
+                .extract().response().asByteArray();
+        var result = deserialize(bytes);
+
+        assertThat(result).isNotEmpty().containsEntry(BPN1, DID1);
+    }
+
+    @DisplayName("Reject VPs that contain a single VC, that is not a MembershipCredential")
+    @Test
+    void getDirectory_validPresentation_notMembershipCred() throws IOException {
+        registerDids();
+
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcIssuerKey, issuerId, "degreeSub", holderId, Map.of("vc", asMap(TestData.SOME_OTHER_CREDENTIAL.formatted(holderId))));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpHolderKey, holderId, null, "bdrs-server-audience", Map.of("vp", asMap(VP_CONTENT_EXAMPLE.formatted(holderId, "\"" + vcJwt1 + "\""))));
+
+        seedServer(BPN1, DID1);
+        getBpnDirectory(apiRequest().header("Authorization", "Bearer " + vpJwt))
+                .statusCode(401);
+    }
+
+    @DisplayName("Reject VP that contains no credentials")
+    @Test
+    void getDirectory_validPresentation_noCredential() throws IOException {
+        registerDids();
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpHolderKey, holderId, null, "bdrs-server-audience", Map.of());
+
+        seedServer(BPN1, DID1);
+        getBpnDirectory(apiRequest().header("Authorization", "Bearer " + vpJwt))
+                .statusCode(401);
+    }
+
+    @DisplayName("Reject VPs, that contain a MC and other credentials")
+    @Test
+    void getDirectory_validPresentation_multipleCredentials() throws IOException {
+        registerDids();
+
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcIssuerKey, issuerId, "degreeSub", holderId, Map.of("vc", asMap(TestData.SOME_OTHER_CREDENTIAL.formatted(holderId))));
+
+
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt2 = JwtCreationUtils.createJwt(vcIssuerKey, issuerId, "degreeSub", holderId, Map.of("vc", asMap(TestData.MEMBERSHIP_CREDENTIAL.formatted(holderId))));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var credentialContent = "\"%s\", \"%s\"".formatted(vcJwt1, vcJwt2);
+        var vpJwt = JwtCreationUtils.createJwt(vpHolderKey, holderId, null, "bdrs-server-audience", Map.of("vp", asMap(VP_CONTENT_EXAMPLE.formatted(holderId, credentialContent))));
+
+        seedServer(BPN1, DID1);
+        getBpnDirectory(apiRequest().header("Authorization", "Bearer " + vpJwt))
+                .statusCode(401);
+    }
+
+    @DisplayName("Reject a spoofed VP")
+    @Test
+    void getDirectory_spoofedPresentation() throws Exception {
+        registerDids();
+
+        var spoofedKey = new ECKeyGenerator(Curve.P_256).keyID(holderId + "#key-1").generate();
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcIssuerKey, issuerId, "degreeSub", holderId, Map.of("vc", asMap(TestData.MEMBERSHIP_CREDENTIAL.formatted(holderId))));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(spoofedKey, holderId, null, "bdrs-server-audience", Map.of("vp", asMap(VP_CONTENT_EXAMPLE.formatted(holderId, "\"" + vcJwt1 + "\""))));
+
+        seedServer(BPN1, DID1);
+        getBpnDirectory(apiRequest().header("Authorization", "Bearer " + vpJwt))
+                .statusCode(401);
+    }
+
+    @DisplayName("Reject a spoofed VC")
+    @Test
+    void getDirectory_spoofedCredential() throws Exception {
+        registerDids();
+
+        var spoofedKey = new ECKeyGenerator(Curve.P_256).keyID(holderId + "#key-1").generate();
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(spoofedKey, issuerId, "degreeSub", holderId, Map.of("vc", asMap(TestData.MEMBERSHIP_CREDENTIAL.formatted(holderId))));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpHolderKey, holderId, null, "bdrs-server-audience", Map.of("vp", asMap(VP_CONTENT_EXAMPLE.formatted(holderId, "\"" + vcJwt1 + "\""))));
+
+        seedServer(BPN1, DID1);
+        getBpnDirectory(apiRequest().header("Authorization", "Bearer " + vpJwt))
+                .statusCode(401);
+    }
+
+    // registers a DidResolver for the "web" method. this method has to be called from a test method!
+    private void registerDids() {
+        runtime.getService(DidResolverRegistry.class)
+                .register(new DidResolver() {
+                    @Override
+                    public @NotNull String getMethod() {
+                        return "web";
+                    }
+
+                    @Override
+                    public @NotNull Result<DidDocument> resolve(String s) {
+                        return Stream.of(vcIssuerKey, vpHolderKey).filter(key -> key.getKeyID().startsWith(s))
+                                .findFirst()
+                                .map(key -> success(createDidDocument(key.toPublicJWK(), s)))
+                                .orElseGet(() -> Result.failure("No such did"));
+                    }
+                });
+    }
+
+    private DidDocument createDidDocument(ECKey publickey, String did) {
+        return DidDocument.Builder.newInstance()
+                .verificationMethod(List.of(VerificationMethod.Builder.newInstance()
+                        .id(publickey.getKeyID())
+                        .publicKeyJwk(publickey.toJSONObject())
+                        .type("JsonWebKey2020")
+                        .build()))
+                .id(did)
+                .build();
     }
 
     private void seedServer(String bpn, String did) {
@@ -129,18 +282,12 @@ public class DirectoryEndToEndTest {
                 .statusCode(204);
     }
 
-    private Map<String, String> getBpnDirectory(RequestSpecification spec) throws IOException {
-        return deserialize(spec
-                .config(config().decoderConfig(decoderConfig().contentDecoders(DEFLATE)))
+    private ValidatableResponse getBpnDirectory(RequestSpecification spec) throws IOException {
+        return spec.config(config().decoderConfig(decoderConfig().contentDecoders(DEFLATE)))
                 .when()
                 .get(BPN_DIRECTORY)
-                .then()
-                .statusCode(200)
-                .extract()
-                .response()
-                .asByteArray());
+                .then();
     }
-
 
     private RequestSpecification apiRequest() {
         return given().baseUri(DIRECTORY_ENDPOINT.toString())
@@ -160,4 +307,12 @@ public class DirectoryEndToEndTest {
         return mapper.readValue(decompressed, Map.class);
     }
 
+    private Map<String, Object> asMap(String rawContent) {
+        try {
+            return mapper.readValue(rawContent, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/ManagementApiEndToEndTest.java
+++ b/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/ManagementApiEndToEndTest.java
@@ -1,0 +1,152 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.bdrs.test.directory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+
+import static io.restassured.RestAssured.config;
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.DecoderConfig.ContentDecoder.DEFLATE;
+import static io.restassured.config.DecoderConfig.decoderConfig;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+
+/**
+ * Performs end-to-end testing of the BPN Directory.
+ */
+@EndToEndTest
+public class ManagementApiEndToEndTest {
+    private static final URI API_ENDPOINT = URI.create("http://localhost:" + getFreePort() + "/api");
+    private static final URI MANAGEMENT_ENDPOINT = URI.create("http://localhost:" + getFreePort() + "/management/v1");
+    private static final URI DIRECTORY_ENDPOINT = URI.create("http://localhost:" + getFreePort() + "/directory/v1");
+    private static final String BPN_DIRECTORY = "bpn-directory";
+
+    private static final String AUTH_KEY = "1234";
+
+    private static final String BPN1 = "BPN12345";
+    private static final String DID1 = "did:web:localhost/foo";
+
+    private static final String BPN2 = "BPN67890";
+    private static final String DID2 = "did:web:localhost/bar";
+    private static final String UPDATED_DID2 = "did:web:localhost/baz";
+
+    @RegisterExtension
+    protected static EdcRuntimeExtension runtime =
+            new EdcRuntimeExtension(
+                    ":system-tests:test-server",
+                    "bdrs",
+                    Map.of("web.http.port", String.valueOf(API_ENDPOINT.getPort()),
+                            "web.http.management.port", String.valueOf(MANAGEMENT_ENDPOINT.getPort()),
+                            "web.http.management.path", String.valueOf(MANAGEMENT_ENDPOINT.getPath()),
+                            "web.http.directory.port", String.valueOf(DIRECTORY_ENDPOINT.getPort()),
+                            "web.http.directory.path", String.valueOf(DIRECTORY_ENDPOINT.getPath()),
+                            "edc.api.auth.key", AUTH_KEY)
+            );
+
+    private ObjectMapper mapper;
+
+
+    @Test
+    void verifyManagementApi() throws IOException {
+        seedServer(BPN1, DID1);
+        seedServer(BPN2, DID2);
+
+        // verify BPNs are returned
+        var result = getBpnDirectory(managementRequest());
+
+        assertThat(result.get(BPN1)).isEqualTo(DID1);
+        assertThat(result.get(BPN2)).isEqualTo(DID2);
+
+        // verify delete
+        managementRequest()
+                .when()
+                .delete(BPN_DIRECTORY + "/" + BPN1)
+                .then()
+                .statusCode(204);
+
+        result = getBpnDirectory(managementRequest());
+
+        assertThat(result.get(BPN1)).isNull();
+        assertThat(result.get(BPN2)).isEqualTo(DID2);
+
+        // verify update
+        var content = Map.of("bpn", BPN2, "did", UPDATED_DID2);
+        managementRequest()
+                .body(content)
+                .when()
+                .put(BPN_DIRECTORY)
+                .then()
+                .statusCode(204);
+
+        result = getBpnDirectory(managementRequest());
+
+        assertThat(result.get(BPN2)).isEqualTo(UPDATED_DID2);
+    }
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper();
+    }
+
+    private void seedServer(String bpn, String did) {
+        var content = Map.of("bpn", bpn, "did", did);
+        managementRequest()
+                .body(content)
+                .when()
+                .post(BPN_DIRECTORY)
+                .then()
+                .statusCode(204);
+    }
+
+    private Map<String, String> getBpnDirectory(RequestSpecification spec) throws IOException {
+        return deserialize(spec
+                .config(config().decoderConfig(decoderConfig().contentDecoders(DEFLATE)))
+                .when()
+                .get(BPN_DIRECTORY)
+                .then()
+                .statusCode(200)
+                .extract()
+                .response()
+                .asByteArray());
+    }
+
+
+    private RequestSpecification managementRequest() {
+        return given().baseUri(MANAGEMENT_ENDPOINT.toString())
+                .headers(Map.of("x-api-key", AUTH_KEY))
+                .contentType(JSON);
+    }
+
+    private Map<String, String> deserialize(byte[] response) throws IOException {
+        var stream = new GZIPInputStream(new ByteArrayInputStream(response));
+        var decompressed = stream.readAllBytes();
+        //noinspection unchecked
+        return mapper.readValue(decompressed, Map.class);
+    }
+
+}

--- a/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/TestData.java
+++ b/system-tests/test-directory/src/test/java/org/eclipse/tractusx/bdrs/test/directory/TestData.java
@@ -1,0 +1,62 @@
+package org.eclipse.tractusx.bdrs.test.directory;
+
+public class TestData {
+    public static final String MEMBERSHIP_CREDENTIAL = """
+            {
+              "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/catenax/credentials/v1.0.0"
+              ],
+              "id": "1f36af58-0fc0-4b24-9b1c-e37d59668089",
+              "type": [
+                "VerifiableCredential",
+                "MembershipCredential"
+              ],
+              "issuer": "did:web:com.example.issuer",
+              "issuanceDate": "2021-06-16T18:56:59Z",
+              "expirationDate": "2099-06-16T18:56:59Z",
+              "credentialSubject": {
+                "id": "%s",
+                "holderIdentifier": "BPNL000000001"
+              }
+            }
+            """;
+
+    public static final String SOME_OTHER_CREDENTIAL = """
+            {
+              "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/catenax/credentials/v1.0.0"
+              ],
+              "id": "1f36af58-0fc0-4b24-9b1c-e37d59668089",
+              "type": [
+                "VerifiableCredential",
+                "SomeOtherCredential"
+              ],
+              "issuer": "did:web:com.example.issuer",
+              "issuanceDate": "2021-06-16T18:56:59Z",
+              "expirationDate": "2099-06-16T18:56:59Z",
+              "credentialSubject": {
+                "id": "%s",
+                "holderIdentifier": "BPNL000000001"
+              }
+            }
+            """;
+
+    public static final String VP_CONTENT_EXAMPLE = """
+                        {
+                            "@context": [
+                              "https://www.w3.org/2018/credentials/v1",
+                              "https://www.w3.org/2018/credentials/examples/v1"
+                            ],
+                            "id": "https://exapmle.com/test-vp",
+                            "holder": "%s",
+                            "type": [
+                              "VerifiablePresentation"
+                            ],
+                            "verifiableCredential": [
+                              %s
+                            ]
+                        }
+            """;
+}

--- a/system-tests/test-server/build.gradle.kts
+++ b/system-tests/test-server/build.gradle.kts
@@ -24,10 +24,16 @@ plugins {
 }
 
 dependencies {
-    runtimeOnly(libs.bundles.bdrs.boot)
     runtimeOnly(project(":core:core-services"))
     runtimeOnly(project(":api:directory-api"))
     runtimeOnly(project(":api:management-api"))
+    runtimeOnly(project(":api:authentication"))
+    // will replace this with a mocked Did Resolver
+    // runtimeOnly(libs.edc.identitydidweb)
+
+    runtimeOnly(libs.edc.identitytrust.issuers)
+    runtimeOnly(libs.bundles.bdrs.boot)
+    runtimeOnly(libs.edc.core.did)
 }
 
 edcBuild {


### PR DESCRIPTION
## WHAT

This PR adds Authorization header validation: the Authorization header must be a JWT-VP, that contains a single valid Membership credential

## WHY

Securing the Directory API of BDRS.

## FURTHER NOTES

- depends on https://github.com/eclipse-edc/Connector/pull/4110

Closes # <-- _insert Issue number if one exists_
