### PR TITLE
feat: add K8s ingress for Mgmt API

### DIFF
--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -89,3 +89,7 @@ jobs:
               echo "BDRS Directory API not ready, status = $code"
               exit 1;
             fi
+            
+            # verify management API is reachable as well. 
+            # in production scenarios, the Managment API should NEVER be on the same ingress as the public API
+            curl -X GET --fail -k -L http://localhost/api/management/bpn-directory -H "content-type: application/json" -H "x-api-key: password" -o -

--- a/charts/bdrs-server-memory/values.yaml
+++ b/charts/bdrs-server-memory/values.yaml
@@ -158,12 +158,35 @@ server:
     ## Public / Internet facing Ingress
     - enabled: false
       # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
-      hostname: "bdrs-server.local"
+      hostname: "bdrs-server.directory.local"
       # -- Additional ingress annotations to add
       annotations: {}
       # -- EDC endpoints exposed by this ingress resource
       endpoints:
         - directory
+      # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+      className: ""
+      # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+      tls:
+        # -- Enables TLS on the ingress resource
+        enabled: false
+        # -- If present overwrites the default secret name
+        secretName: ""
+      ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+      certManager:
+        # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+        issuer: ""
+        # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+        clusterIssuer: ""
+    ## Ingress for the Management API, should not be internet facing
+    - enabled: false
+      # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+      hostname: "bdrs-server.mgmt.local"
+      # -- Additional ingress annotations to add
+      annotations: { }
+      # -- EDC endpoints exposed by this ingress resource
+      endpoints:
+        - management
       # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
       className: ""
       # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource

--- a/system-tests/helm/values-test.yaml
+++ b/system-tests/helm/values-test.yaml
@@ -24,6 +24,7 @@ server:
       hostname: "localhost"
       endpoints:
         - directory
+        - management
       className: "nginx"
       tls:
         enabled: true


### PR DESCRIPTION
## WHAT

Adds another `ingress` object to the `values.yaml` file

## WHY

The Management API may need to be exposed using an ingress route. 


## FURTHER NOTES

Do _not_ expose the Management API to the internet without additional infrastructure!

Closes # <-- _insert Issue number if one exists_
