### PR TITLE
fix(bdrs-server): use correct image in chart

### DIFF
--- a/charts/bdrs-server/templates/deployment.yaml
+++ b/charts/bdrs-server/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           {{- if .Values.server.image.repository }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           {{- else }}
-          image: "tractusx/bdrs-server-memory:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          image: "tractusx/bdrs-server:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           {{- end }}
 
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}


### PR DESCRIPTION
## WHAT

use correct image in helm chart: follow up to https://github.com/eclipse-tractusx/bpn-did-resolution-service/commit/ce7524c4835cd9baa52fc0eb35899ff444af10eb

## WHY

wrong image