### PR TITLE
fix: add Trusted Issuers to helm template

### DIFF
--- a/charts/bdrs-server-memory/README.md
+++ b/charts/bdrs-server-memory/README.md
@@ -52,15 +52,15 @@ helm install my-release tractusx-edc/bdrs-server --version 0.0.3 \
 | server.debug.enabled | bool | `false` |  |
 | server.debug.port | int | `1044` |  |
 | server.debug.suspendOnStart | bool | `false` |  |
-| server.endpoints | object | `{"default":{"path":"/api","port":8080},"directory":{"path":"/api/directory","port":8082},"management":{"authKey":"password","path":"/api/management","port":8081}}` | endpoints of the control plane |
+| server.endpoints | object | `{"default":{"path":"/api","port":8080},"directory":{"path":"/api/directory","port":8082},"management":{"authKeyAlias":"mgmt-api-key","path":"/api/management","port":8081}}` | endpoints of the control plane |
 | server.endpoints.default | object | `{"path":"/api","port":8080}` | default api for health checks, should not be added to any ingress |
 | server.endpoints.default.path | string | `"/api"` | path for incoming api calls |
 | server.endpoints.default.port | int | `8080` | port for incoming api calls |
 | server.endpoints.directory | object | `{"path":"/api/directory","port":8082}` | directory API |
 | server.endpoints.directory.path | string | `"/api/directory"` | path for incoming api calls |
 | server.endpoints.directory.port | int | `8082` | port for incoming api calls |
-| server.endpoints.management | object | `{"authKey":"password","path":"/api/management","port":8081}` | management api, used by internal users, can be added to an ingress and must not be internet facing |
-| server.endpoints.management.authKey | string | `"password"` | authentication key, must be attached to each 'X-Api-Key' request header |
+| server.endpoints.management | object | `{"authKeyAlias":"mgmt-api-key","path":"/api/management","port":8081}` | management api, used by internal users, can be added to an ingress and must not be internet facing |
+| server.endpoints.management.authKeyAlias | string | `"mgmt-api-key"` | authentication key, must be attached to each 'X-Api-Key' request header |
 | server.endpoints.management.path | string | `"/api/management"` | path for incoming api calls |
 | server.endpoints.management.port | int | `8081` | port for incoming api calls |
 | server.env | object | `{}` |  |
@@ -127,6 +127,7 @@ helm install my-release tractusx-edc/bdrs-server --version 0.0.3 \
 | server.service.annotations | object | `{}` |  |
 | server.service.type | string | `"ClusterIP"` | [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service. |
 | server.tolerations | list | `[]` |  |
+| server.trustedIssuers | list | `[]` | Configures the trusted issuers for this runtime |
 | server.url.protocol | string | `""` | Explicitly declared url for reaching the dsp api (e.g. if ingresses not used) |
 | server.url.public | string | `""` |  |
 | server.url.readiness | string | `""` |  |

--- a/charts/bdrs-server-memory/README.md
+++ b/charts/bdrs-server-memory/README.md
@@ -52,15 +52,15 @@ helm install my-release tractusx-edc/bdrs-server --version 0.0.3 \
 | server.debug.enabled | bool | `false` |  |
 | server.debug.port | int | `1044` |  |
 | server.debug.suspendOnStart | bool | `false` |  |
-| server.endpoints | object | `{"default":{"path":"/api","port":8080},"directory":{"path":"/api/directory","port":8082},"management":{"authKeyAlias":"mgmt-api-key","path":"/api/management","port":8081}}` | endpoints of the control plane |
+| server.endpoints | object | `{"default":{"path":"/api","port":8080},"directory":{"path":"/api/directory","port":8082},"management":{"authKey":"password","path":"/api/management","port":8081}}` | endpoints of the control plane |
 | server.endpoints.default | object | `{"path":"/api","port":8080}` | default api for health checks, should not be added to any ingress |
 | server.endpoints.default.path | string | `"/api"` | path for incoming api calls |
 | server.endpoints.default.port | int | `8080` | port for incoming api calls |
 | server.endpoints.directory | object | `{"path":"/api/directory","port":8082}` | directory API |
 | server.endpoints.directory.path | string | `"/api/directory"` | path for incoming api calls |
 | server.endpoints.directory.port | int | `8082` | port for incoming api calls |
-| server.endpoints.management | object | `{"authKeyAlias":"mgmt-api-key","path":"/api/management","port":8081}` | management api, used by internal users, can be added to an ingress and must not be internet facing |
-| server.endpoints.management.authKeyAlias | string | `"mgmt-api-key"` | authentication key, must be attached to each 'X-Api-Key' request header |
+| server.endpoints.management | object | `{"authKey":"password","path":"/api/management","port":8081}` | management api, used by internal users, can be added to an ingress and must not be internet facing |
+| server.endpoints.management.authKey | string | `"password"` | authentication key, must be attached to each 'X-Api-Key' request header |
 | server.endpoints.management.path | string | `"/api/management"` | path for incoming api calls |
 | server.endpoints.management.port | int | `8081` | port for incoming api calls |
 | server.env | object | `{}` |  |
@@ -127,7 +127,7 @@ helm install my-release tractusx-edc/bdrs-server --version 0.0.3 \
 | server.service.annotations | object | `{}` |  |
 | server.service.type | string | `"ClusterIP"` | [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service. |
 | server.tolerations | list | `[]` |  |
-| server.trustedIssuers | list | `[]` | Configures the trusted issuers for this runtime |
+| server.trustedIssuers | list | `[]` | Configures the trusted issuers for this runtime. Must not be empty. |
 | server.url.protocol | string | `""` | Explicitly declared url for reaching the dsp api (e.g. if ingresses not used) |
 | server.url.public | string | `""` |  |
 | server.url.readiness | string | `""` |  |

--- a/charts/bdrs-server-memory/templates/deployment.yaml
+++ b/charts/bdrs-server-memory/templates/deployment.yaml
@@ -145,8 +145,8 @@ spec:
             #######
             # API #
             #######
-            - name: "EDC_API_AUTH_KEY_ALIAS"
-              value: {{ .Values.server.endpoints.management.authKeyAlias | required ".Values.runtime.endpoints.management.authKeyAlias is required" | quote }}
+            - name: "EDC_API_AUTH_KEY"
+              value: {{ .Values.server.endpoints.management.authKey | required ".Values.runtime.endpoints.management.authKey is required" | quote }}
             - name: "WEB_HTTP_PORT"
               value: {{ .Values.server.endpoints.default.port | quote }}
             - name: "WEB_HTTP_PATH"

--- a/charts/bdrs-server-memory/templates/deployment.yaml
+++ b/charts/bdrs-server-memory/templates/deployment.yaml
@@ -163,9 +163,13 @@ spec:
             #############################
             ## TRUSTED ISSUER CONFIG
             #############################
+            {{- if empty .Values.server.trustedIssuers }}
+            {{- required "List of trusted issuers cannot be empty!" "" }}
+            {{- else }}
             {{- range $index, $issuer := .Values.server.trustedIssuers }}
             - name: "EDC_IAM_TRUSTED-ISSUER_{{$index}}-ISSUER_ID"
               value: {{ $issuer | quote }}
+            {{- end }}
             {{- end }}
 
             ######################################

--- a/charts/bdrs-server-memory/templates/deployment.yaml
+++ b/charts/bdrs-server-memory/templates/deployment.yaml
@@ -145,8 +145,8 @@ spec:
             #######
             # API #
             #######
-            - name: "EDC_API_AUTH_KEY"
-              value: {{ .Values.server.endpoints.management.authKey | required ".Values.runtime.endpoints.management.authKey is required" | quote }}
+            - name: "EDC_API_AUTH_KEY_ALIAS"
+              value: {{ .Values.server.endpoints.management.authKeyAlias | required ".Values.runtime.endpoints.management.authKeyAlias is required" | quote }}
             - name: "WEB_HTTP_PORT"
               value: {{ .Values.server.endpoints.default.port | quote }}
             - name: "WEB_HTTP_PATH"
@@ -159,6 +159,14 @@ spec:
               value: {{ .Values.server.endpoints.directory.port | quote }}
             - name: "WEB_HTTP_DIRECTORY_PATH"
               value: {{ .Values.server.endpoints.directory.path | quote }}
+
+            #############################
+            ## TRUSTED ISSUER CONFIG
+            #############################
+            {{- range $index, $issuer := .Values.server.trustedIssuers }}
+            - name: "EDC_IAM_TRUSTED-ISSUER_{{$index}}-ISSUER_ID"
+              value: {{ $issuer | quote }}
+            {{- end }}
 
             ######################################
             ## Additional environment variables ##

--- a/charts/bdrs-server-memory/templates/tests/test.yaml
+++ b/charts/bdrs-server-memory/templates/tests/test.yaml
@@ -36,11 +36,6 @@ spec:
       image: curlimages/curl
       command: [ 'curl', '--fail' ]
       args: [ '{{- printf "http://%s:%v%s/check/readiness" (include "bdrs.fullname" $ ) $.Values.server.endpoints.default.port $.Values.server.endpoints.default.path -}}' ]
-    {{/* Try getting a BPN/DID mapping via the management API   */}}
-    - name: bdrs-management-api
-      image: curlimages/curl
-      command: [ 'curl', '-i', '--fail', '-X', 'GET', '-H', '{{- printf "x-api-key: %s" $.Values.server.endpoints.management.authKey }}' ]
-      args: [ '{{- printf "http://%s:%v%s/bpn-directory" (include "bdrs.fullname" $ ) $.Values.server.endpoints.management.port $.Values.server.endpoints.management.path -}}' ]
   restartPolicy: Never
   securityContext:
     fsGroup: 101 # curl_group

--- a/charts/bdrs-server-memory/values.yaml
+++ b/charts/bdrs-server-memory/values.yaml
@@ -84,7 +84,7 @@ server:
       # -- path for incoming api calls
       path: /api/management
       # -- authentication key, must be attached to each 'X-Api-Key' request header
-      authKey: "password"
+      authKeyAlias: "mgmt-api-key"
     # -- directory API
     directory:
       # -- port for incoming api calls
@@ -92,6 +92,9 @@ server:
       # -- path for incoming api calls
       path: /api/directory
     # -- dsp api, used for inter connector communication and must be internet facing
+
+  # -- Configures the trusted issuers for this runtime
+  trustedIssuers: []
 
   service:
     # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.

--- a/charts/bdrs-server-memory/values.yaml
+++ b/charts/bdrs-server-memory/values.yaml
@@ -93,7 +93,7 @@ server:
       path: /api/directory
     # -- dsp api, used for inter connector communication and must be internet facing
 
-  # -- Configures the trusted issuers for this runtime
+  # -- Configures the trusted issuers for this runtime. Must not be empty.
   trustedIssuers: []
 
   service:

--- a/charts/bdrs-server-memory/values.yaml
+++ b/charts/bdrs-server-memory/values.yaml
@@ -84,7 +84,7 @@ server:
       # -- path for incoming api calls
       path: /api/management
       # -- authentication key, must be attached to each 'X-Api-Key' request header
-      authKeyAlias: "mgmt-api-key"
+      authKey: "password"
     # -- directory API
     directory:
       # -- port for incoming api calls

--- a/charts/bdrs-server/README.md
+++ b/charts/bdrs-server/README.md
@@ -139,7 +139,7 @@ helm install my-release tractusx-edc/bdrs-server --version 0.0.3 \
 | server.service.annotations | object | `{}` |  |
 | server.service.type | string | `"ClusterIP"` | [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service. |
 | server.tolerations | list | `[]` |  |
-| server.trustedIssuers | list | `[]` | Configures the trusted issuers for this runtime |
+| server.trustedIssuers | list | `[]` | Configures the trusted issuers for this runtime. Must not be empty. |
 | server.url.protocol | string | `""` | Explicitly declared url for reaching the dsp api (e.g. if ingresses not used) |
 | server.url.public | string | `""` |  |
 | server.url.readiness | string | `""` |  |

--- a/charts/bdrs-server/README.md
+++ b/charts/bdrs-server/README.md
@@ -139,6 +139,7 @@ helm install my-release tractusx-edc/bdrs-server --version 0.0.3 \
 | server.service.annotations | object | `{}` |  |
 | server.service.type | string | `"ClusterIP"` | [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service. |
 | server.tolerations | list | `[]` |  |
+| server.trustedIssuers | list | `[]` | Configures the trusted issuers for this runtime |
 | server.url.protocol | string | `""` | Explicitly declared url for reaching the dsp api (e.g. if ingresses not used) |
 | server.url.public | string | `""` |  |
 | server.url.readiness | string | `""` |  |

--- a/charts/bdrs-server/templates/deployment.yaml
+++ b/charts/bdrs-server/templates/deployment.yaml
@@ -195,9 +195,13 @@ spec:
             #############################
             ## TRUSTED ISSUER CONFIG
             #############################
+            {{- if empty .Values.server.trustedIssuers }}
+            {{- required "List of trusted issuers cannot be empty!" "" }}
+            {{- else }}
             {{- range $index, $issuer := .Values.server.trustedIssuers }}
             - name: "EDC_IAM_TRUSTED-ISSUER_{{$index}}-ISSUER_ID"
               value: {{ $issuer | quote }}
+            {{- end }}
             {{- end }}
 
             ######################################

--- a/charts/bdrs-server/templates/deployment.yaml
+++ b/charts/bdrs-server/templates/deployment.yaml
@@ -192,6 +192,14 @@ spec:
               value: {{ .Values.vault.hashicorp.paths.health | quote }}
 
 
+            #############################
+            ## TRUSTED ISSUER CONFIG
+            #############################
+            {{- range $index, $issuer := .Values.server.trustedIssuers }}
+            - name: "EDC_IAM_TRUSTED-ISSUER_{{$index}}-ISSUER_ID"
+              value: {{ $issuer | quote }}
+            {{- end }}
+
             ######################################
             ## Additional environment variables ##
             ######################################

--- a/charts/bdrs-server/values.yaml
+++ b/charts/bdrs-server/values.yaml
@@ -98,6 +98,9 @@ server:
       path: /api/directory
     # -- dsp api, used for inter connector communication and must be internet facing
 
+  # -- Configures the trusted issuers for this runtime
+  trustedIssuers: []
+
   service:
     # -- [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service.
     type: ClusterIP

--- a/charts/bdrs-server/values.yaml
+++ b/charts/bdrs-server/values.yaml
@@ -98,7 +98,7 @@ server:
       path: /api/directory
     # -- dsp api, used for inter connector communication and must be internet facing
 
-  # -- Configures the trusted issuers for this runtime
+  # -- Configures the trusted issuers for this runtime. Must not be empty.
   trustedIssuers: []
 
   service:

--- a/system-tests/helm/values-test.yaml
+++ b/system-tests/helm/values-test.yaml
@@ -22,6 +22,11 @@
 install:
   vault: false
 server:
+  trustedIssuers:
+    # these must be the DIDs of the dataspace credential issuer
+    - "did:web:tractusx-issuer1"
+    - "did:web:tractusx-issuer2"
+
   ingresses:
     - enabled: true
       hostname: "localhost"


### PR DESCRIPTION
## WHAT

adds the trusted issuers list to the helm template. check out `system-tests/helm/values.test.yaml` for an example how to configure them.

## WHY

having go configure the `EDC_IAM_TRUSTED-ISSUER_<ISSUER>-ISSUER_ID=did:web:...` environment variable was possible before using the `server.env` object, but this makes
it more explicit.

## FURTHER NOTES

- in the `memory` chart there was also still the old api key config. fixed that as well.

Closes # <-- _insert Issue number if one exists_
