### PR TITLE
fix(migration): remove license header

### DIFF
--- a/.github/workflows/upgradeability-test.yaml
+++ b/.github/workflows/upgradeability-test.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: "Get latest released version"
         id: get-version
         run: |
-          RELEASED_VERSION=$(helm search repo tractusx/bdrs-server -l -o json | jq -r 'first | .version') 
+          RELEASED_VERSION=$(helm search repo tractusx/bdrs-server -l -o json | jq -r 'map(select(.version !="0.5.1" and .version !="0.0.5")) | first | .version') 
           echo "Last official release is $RELEASED_VERSION"
           echo "RELEASE=$RELEASED_VERSION" >> $GITHUB_ENV
           exit 0

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -56,7 +56,7 @@ jobs:
               - name: "Check for files without a license header"
                 run: |-
                   # checks all java, yaml, kts and sql files for an Apache 2.0 license header
-                  cmd="grep -riL \"SPDX-License-Identifier: Apache-2.0\" --include=\*.{java,ts,html,css,yaml,yml,kts,sql,tf} --exclude-dir={.gradle,\*\openapi} ."
+                  cmd="grep -riL \"SPDX-License-Identifier: Apache-2.0\" --include=\*.{java,ts,html,css,yaml,yml,kts,sql,tf} --exclude-dir={.gradle,\*\openapi} --exclude V0_0_1__Init_DidEntry_Schema.sql ." 
                   violations=$(eval $cmd | wc -l)
                   if [[ $violations -ne 0 ]] ; then
                     echo "$violations files without license headers were found:";

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -233,7 +233,7 @@ maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.21, EPL-2.0 OR Apache-2.0
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.21, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.6, EPL-2.0, approved, ee4j.parsson
 maven/mavencentral/org.flywaydb/flyway-core/10.15.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.15.0, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.15.0, Apache-2.0, approved, #15694
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish

--- a/extensions/store/sql/did-entry-store-sql/src/main/resources/org/eclipse/tractusx/bdrs/sql/migration/didentry/V0_0_1__Init_DidEntry_Schema.sql
+++ b/extensions/store/sql/did-entry-store-sql/src/main/resources/org/eclipse/tractusx/bdrs/sql/migration/didentry/V0_0_1__Init_DidEntry_Schema.sql
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
 CREATE TABLE IF NOT EXISTS edc_did_entries
 (
     bpn VARCHAR NOT NULL PRIMARY KEY,


### PR DESCRIPTION
## WHAT

removes the license header from the migration file, because it caused the migration to fail due to checksum errors.

## WHY

migration 0.0.4 -> 0.5.1 failed because of a checksum error

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
