### PR TITLE
chore: add example resource limits for postgres configuration

### DIFF
--- a/charts/bdrs-server/README.md
+++ b/charts/bdrs-server/README.md
@@ -54,7 +54,15 @@ helm install my-release tractusx-edc/bdrs-server --version 0.5.2 \
 | postgresql.auth.username | string | `"bdrs"` |  |
 | postgresql.jdbcUrl | string | `"jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/bdrs"` |  |
 | postgresql.primary.persistence.enabled | bool | `false` |  |
+| postgresql.primary.resources.limits.cpu | int | `1` |  |
+| postgresql.primary.resources.limits.memory | string | `"1Gi"` |  |
+| postgresql.primary.resources.requests.cpu | string | `"250m"` |  |
+| postgresql.primary.resources.requests.memory | string | `"256Mi"` |  |
 | postgresql.readReplicas.persistence.enabled | bool | `false` |  |
+| postgresql.readReplicas.resources.limits.cpu | string | `"500Mi"` |  |
+| postgresql.readReplicas.resources.limits.memory | string | `"1Gi"` |  |
+| postgresql.readReplicas.resources.requests.cpu | string | `"250m"` |  |
+| postgresql.readReplicas.resources.requests.memory | string | `"256Mi"` |  |
 | server.affinity | object | `{}` |  |
 | server.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | server.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |

--- a/charts/bdrs-server/values.yaml
+++ b/charts/bdrs-server/values.yaml
@@ -276,9 +276,23 @@ postgresql:
   primary:
     persistence:
       enabled: false
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
   readReplicas:
     persistence:
       enabled: false
+    resources:
+      limits:
+        cpu: 500Mi
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
   auth:
     database: "bdrs"
     username: "bdrs"


### PR DESCRIPTION
## WHAT

Previously the postgresql deployment in the helm charts does not state any resource constraints and relies on the constraints of the referred charts. Proposed solution is to add an example resource constraint.

## WHY

During deployment in a test environment, it took a while to figure out, how the resource constraint have to be defined. By providing a commented example for setting the constraints, an adopter does not have to research for the right configuration but can simply uncomment or copy the proposal and adapt it accordingly.

## FURTHER NOTES

n/a

Closes #80