### PR TITLE
chore: Downgrade postgres version to prevent version updates

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -254,8 +254,8 @@ maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.24, EPL-2.0 OR Apache-2.0, 
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.24, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.24, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.7, EPL-2.0, approved, ee4j.parsson
-maven/mavencentral/org.flywaydb/flyway-core/11.2.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.flywaydb/flyway-database-postgresql/11.2.0, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-core/11.3.0, , restricted, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-database-postgresql/11.3.0, , restricted, clearlydefined
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish

--- a/charts/bdrs-server/Chart.yaml
+++ b/charts/bdrs-server/Chart.yaml
@@ -47,7 +47,7 @@ dependencies:
   # PostgreSQL
   - name: postgresql
     alias: postgresql
-    version: 15.2.1
+    version: 12.11.2
     repository: https://charts.bitnami.com/bitnami
     condition: install.postgresql
   # HashiCorp Vault

--- a/charts/bdrs-server/README.md
+++ b/charts/bdrs-server/README.md
@@ -35,7 +35,7 @@ helm install my-release tractusx-edc/bdrs-server --version 0.5.3 \
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 15.2.1 |
+| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 12.11.2 |
 | https://helm.releases.hashicorp.com | vault(vault) | 0.28.0 |
 
 ## Values


### PR DESCRIPTION
## WHAT

The update done updated the postgres database version from 15 to 16. This has been reverted.

## WHY

- Prevent version upgrade procedures on test environments
- Meet TRG requirements
