### PR TITLE
build(deps): bump EDC to 0.12.0

### DIFF
--- a/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationExtension.java
+++ b/api/authentication/src/main/java/org/eclipse/tractusx/bdrs/api/directory/authentication/CredentialBasedAuthenticationExtension.java
@@ -48,20 +48,19 @@ import org.eclipse.edc.web.spi.WebService;
 import java.time.Clock;
 
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
-import static org.eclipse.tractusx.bdrs.api.directory.authentication.CredentialBasedAuthenticationExtension.NAME;
 
 /**
  * Registers an authentication service that checks MembershipCredentials.
  */
-@Extension(NAME)
+@Extension(CredentialBasedAuthenticationExtension.EXTENSION_NAME)
 public class CredentialBasedAuthenticationExtension implements ServiceExtension {
 
-    public static final String NAME = "Directory API Authentication Extension";
+    public static final String EXTENSION_NAME = "Directory API Authentication Extension";
 
     private static final long DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS = 15 * 60 * 1000L;
     private static final String DIRECTORY_CONTEXT = "directory";
 
-    @Setting(value = "Validity period of cached StatusList2021 credential entries in milliseconds.", defaultValue = DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS + "", type = "long")
+    @Setting(description = "Validity period of cached StatusList2021 credential entries in milliseconds.", defaultValue = DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS + "")
     public static final String REVOCATION_CACHE_VALIDITY = "edc.iam.credential.revocation.cache.validity";
 
     @Inject
@@ -87,20 +86,19 @@ public class CredentialBasedAuthenticationExtension implements ServiceExtension 
 
     @Override
     public String name() {
-        return NAME;
+        return EXTENSION_NAME;
     }
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var mapper = typeManager.getMapper(JSON_LD);
         // the DidPublicKeyResolver has a dependency onto the KeyParserRegistry, so that must be created in a separate ext -> KeyParserRegistryExtension
-        var jwtVerifier = new JwtPresentationVerifier(mapper, tokenValidationService, rulesRegistry, didPublicKeyResolver);
+        var jwtVerifier = new JwtPresentationVerifier(typeManager, JSON_LD, tokenValidationService, rulesRegistry, didPublicKeyResolver);
         var presentationVerifier = new MultiFormatPresentationVerifier(null, jwtVerifier);
 
         var validity = context.getConfig().getLong(REVOCATION_CACHE_VALIDITY, DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS);
         revocationServiceRegistry.addService(StatusList2021Status.TYPE, new StatusList2021RevocationService(typeManager.getMapper(), validity));
         revocationServiceRegistry.addService(BitstringStatusListStatus.TYPE, new BitstringStatusListRevocationService(typeManager.getMapper(), validity));
-        var validationService = new VerifiableCredentialValidationServiceImpl(presentationVerifier, trustedIssuerRegistry, revocationServiceRegistry, clock);
+        var validationService = new VerifiableCredentialValidationServiceImpl(presentationVerifier, trustedIssuerRegistry, revocationServiceRegistry, clock, typeManager.getMapper());
 
         var authService = new CredentialBasedAuthenticationService(context.getMonitor(), typeManager.getMapper(), validationService, typeTransformerRegistry);
         registry.register(DIRECTORY_CONTEXT, authService);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 assertj = "3.27.3"
-edc = "0.11.1"
+edc = "0.12.0"
 nimbus = "10.0.2"
 restAssured = "5.5.1"
 jupiter = "5.11.4"


### PR DESCRIPTION
## WHAT

Update the dependency to the upstream connector framework to version 0.12.0


## WHY

To stay on the latest developments and to ensure update of transitive dependencies to the currently used ones

