### PR TITLE
feat: introduce log level configuration

### DIFF
--- a/charts/bdrs-server-memory/templates/configmap.yaml
+++ b/charts/bdrs-server-memory/templates/configmap.yaml
@@ -28,6 +28,3 @@ metadata:
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "bdrs.server.labels" . | nindent 4 }}
-data:
-  logging.properties: |-
-    {{- .Values.server.logging | nindent 4 }}

--- a/charts/bdrs-server-memory/templates/deployment.yaml
+++ b/charts/bdrs-server-memory/templates/deployment.yaml
@@ -99,6 +99,7 @@ spec:
           image: "tractusx/bdrs-server-memory:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           {{- end }}
 
+          args: [ --log-level={{ .Values.server.logs.level | required ".Values.server.logs.level is required" }} ]
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           ports:
           {{- range $key,$value := .Values.server.endpoints }}
@@ -210,12 +211,6 @@ spec:
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
-        - name: "configuration"
-          configMap:
-            name: {{ include "bdrs.fullname" . }}
-            items:
-              - key: "logging.properties"
-                path: "logging.properties"
         {{- if .Values.customCaCerts }}
         - name: custom-cacertificates
           configMap:

--- a/charts/bdrs-server-memory/values.yaml
+++ b/charts/bdrs-server-memory/values.yaml
@@ -40,6 +40,9 @@ server:
     # -- Overrides the image tag whose default is the chart appVersion
     tag: ""
   initContainers: []
+  logs:
+    # -- Defines the log granularity of the default Console Monitor.
+    level: INFO
   debug:
     enabled: false
     port: 1044
@@ -231,14 +234,6 @@ server:
     targetCPUUtilizationPercentage: 80
     # -- targetAverageUtilization of memory provided to a pod
     targetMemoryUtilizationPercentage: 80
-  # -- configuration of the [Java Util Logging Facade](https://docs.oracle.com/javase/7/docs/technotes/guides/logging/overview.html)
-  logging: |-
-    .level=INFO
-    org.eclipse.edc.level=ALL
-    handlers=java.util.logging.ConsoleHandler
-    java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-    java.util.logging.ConsoleHandler.level=ALL
-    java.util.logging.SimpleFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS] [%4$-7s] %5$s%6$s%n
   # [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain pods to nodes
   nodeSelector: {}
   # [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to configure preferred nodes

--- a/charts/bdrs-server/templates/configmap.yaml
+++ b/charts/bdrs-server/templates/configmap.yaml
@@ -28,6 +28,4 @@ metadata:
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "bdrs.server.labels" . | nindent 4 }}
-data:
-  logging.properties: |-
-    {{- .Values.server.logging | nindent 4 }}
+

--- a/charts/bdrs-server/templates/deployment.yaml
+++ b/charts/bdrs-server/templates/deployment.yaml
@@ -99,6 +99,7 @@ spec:
           image: "tractusx/bdrs-server:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           {{- end }}
 
+          args: [ --log-level={{ .Values.server.logs.level | required ".Values.server.logs.level is required" }} ]
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           ports:
           {{- range $key,$value := .Values.server.endpoints }}
@@ -241,12 +242,6 @@ spec:
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
-        - name: "configuration"
-          configMap:
-            name: {{ include "bdrs.fullname" . }}
-            items:
-              - key: "logging.properties"
-                path: "logging.properties"
         {{- if .Values.customCaCerts }}
         - name: custom-cacertificates
           configMap:

--- a/charts/bdrs-server/values.yaml
+++ b/charts/bdrs-server/values.yaml
@@ -45,6 +45,9 @@ server:
     # -- Overrides the image tag whose default is the chart appVersion
     tag: ""
   initContainers: []
+  logs:
+    # -- Defines the log granularity of the default Console Monitor.
+    level: DEBUG
   debug:
     enabled: false
     port: 1044
@@ -236,14 +239,6 @@ server:
     targetCPUUtilizationPercentage: 80
     # -- targetAverageUtilization of memory provided to a pod
     targetMemoryUtilizationPercentage: 80
-  # -- configuration of the [Java Util Logging Facade](https://docs.oracle.com/javase/7/docs/technotes/guides/logging/overview.html)
-  logging: |-
-    .level=INFO
-    org.eclipse.edc.level=ALL
-    handlers=java.util.logging.ConsoleHandler
-    java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-    java.util.logging.ConsoleHandler.level=ALL
-    java.util.logging.SimpleFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS] [%4$-7s] %5$s%6$s%n
   # [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain pods to nodes
   nodeSelector: {}
   # [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to configure preferred nodes

--- a/runtimes/bdrs-server-memory/src/main/docker/Dockerfile
+++ b/runtimes/bdrs-server-memory/src/main/docker/Dockerfile
@@ -40,8 +40,6 @@ ENV EDC_CONNECTOR_NAME="BDRS"
 
 HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:8080/api/check/health
 
-# Use "exec" for graceful termination (SIGINT) to reach JVM.
 # ARG can not be used in ENTRYPOINT so storing value in an ENV variable
 ENV ENV_JVM_ARGS=$JVM_ARGS
-# use the "exec" syntax so that SIGINT reaches the JVM -> graceful termination
-CMD ["sh", "-c", "exec java  -Djava.util.logging.config.file=/app/logging.properties -Djava.security.egd=file:/dev/urandom -jar server.jar"]
+ENTRYPOINT ["java", "-Djava.util.logging.config.file=/app/logging.properties", "-Djava.security.egd=file:/dev/urandom", "-jar", "server.jar"]

--- a/runtimes/bdrs-server/src/main/docker/Dockerfile
+++ b/runtimes/bdrs-server/src/main/docker/Dockerfile
@@ -40,8 +40,6 @@ ENV EDC_CONNECTOR_NAME="BDRS"
 
 HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:8080/api/check/health
 
-# Use "exec" for graceful termination (SIGINT) to reach JVM.
 # ARG can not be used in ENTRYPOINT so storing value in an ENV variable
 ENV ENV_JVM_ARGS=$JVM_ARGS
-# use the "exec" syntax so that SIGINT reaches the JVM -> graceful termination
-CMD ["sh", "-c", "exec java  -Djava.util.logging.config.file=/app/logging.properties -Djava.security.egd=file:/dev/urandom -jar server.jar"]
+ENTRYPOINT ["java", "-Djava.util.logging.config.file=/app/logging.properties", "-Djava.security.egd=file:/dev/urandom", "-jar", "server.jar"]


### PR DESCRIPTION
## WHAT & WHY

Changes the existing entrypoint instruction in the Dockerfiles to allow command line arguments to be appended to the executable, and introduce the `--log-level` command argument for configurable log level granularity.


## FURTHER NOTES

Removed `logging.properties` as they had no effect.

Closes #184 
