### PR TITLE
chore: Switch to new central snapshot sonatype repo

### DIFF
--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -20,7 +20,7 @@
 
 
 ---
-name: "Manually publish Maven Artefacts to OSSRH"
+name: "Manually publish Maven Artefacts to Maven Central"
 
 on:
   workflow_dispatch:
@@ -55,8 +55,8 @@ jobs:
       # publish releases
       - name: Publish version
         env:
-          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
+          CENTRAL_SONATYPE_TOKEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          CENTRAL_SONATYPE_TOKEN_USER: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
         run: |-
           if [ -z ${{ inputs.version }} ]; 
           then 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -84,8 +84,8 @@ jobs:
       # publish releases
       - name: Publish version
         env:
-          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
+          CENTRAL_SONATYPE_TOKEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          CENTRAL_SONATYPE_TOKEN_USER: ${{ CENTRAL_SONATYPE_TOKEN_USERNAME }}
         run: |-
           echo "Publishing Version $RELEASE_VERSION to Sonatype/MavenCentral"
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Pversion=$RELEASE_VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,8 +59,8 @@ jobs:
           [ ! -z "${{ secrets.DOCKER_HUB_TOKEN }}" ] && echo "DOCKER_HUB_TOKEN=true" >> $GITHUB_OUTPUT
           [ ! -z "${{ secrets.ORG_GPG_PASSPHRASE }}" ] &&
           [ ! -z "${{ secrets.ORG_GPG_PRIVATE_KEY }}" ] &&
-          [ ! -z "${{ secrets.ORG_OSSRH_USERNAME }}" ] &&
-          [ ! -z "${{ secrets.ORG_OSSRH_PASSWORD }}" ]  && echo "HAS_OSSRH=true" >> $GITHUB_OUTPUT
+          [ ! -z "${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}" ] &&
+          [ ! -z "${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}" ]  && echo "HAS_OSSRH=true" >> $GITHUB_OUTPUT
           exit 0
 
   build-docker-images:
@@ -116,10 +116,10 @@ jobs:
       # publish snapshots or releases
       - name: Publish version
         env:
-          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
+          CENTRAL_SONATYPE_TOKEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          CENTRAL_SONATYPE_TOKEN_USER: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
         run: |-
-          echo "::warning file=.github/workflows/publish.yaml line=120 title=Publishing to Maven is disabled::Publishing to MavenCentral/OSSRH is disabled for now"
+          echo "::warning file=.github/workflows/publish.yaml line=120 title=Publishing to Maven is disabled::Publishing to MavenCentral is disabled for now"
           exit 0
           
           VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ group=org.eclipse.tractusx
 version=0.5.5-SNAPSHOT
 # these define the versions of the EDC Build Plugin, the Annotation Processor and the Metamodel.
 # generally this should match the version of EDC in gradle/libs.versions.toml
-edcGradlePluginsVersion=0.12.0
+edcGradlePluginsVersion=0.14.0-20250626-SNAPSHOT
 annotationProcessorVersion=0.5.1
 metaModelVersion=0.5.1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,21 +22,10 @@ pluginManagement {
     repositories {
         mavenLocal()
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
         mavenCentral()
         gradlePluginPortal()
-    }
-}
-
-dependencyResolutionManagement {
-
-    repositories {
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
-        mavenCentral()
-        mavenLocal()
     }
 }
 


### PR DESCRIPTION
## WHAT

Switch from oss.sonatype.org to central.sonatype.com as requested

## WHY

Requested by Sonatype

Fixes #208 
