### PR TITLE
chore: Switch to bitnami legacy postgres image

### DIFF
--- a/charts/bdrs-server/README.md
+++ b/charts/bdrs-server/README.md
@@ -52,6 +52,8 @@ helm install my-release tractusx-edc/bdrs-server --version 0.5.6 \
 | postgresql.auth.database | string | `"bdrs"` |  |
 | postgresql.auth.password | string | `"password"` |  |
 | postgresql.auth.username | string | `"bdrs"` |  |
+| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` | workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts |
+| postgresql.image.tag | string | `"15.4.0-debian-11-r45"` | workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts |
 | postgresql.jdbcUrl | string | `"jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/bdrs"` |  |
 | postgresql.primary.persistence.enabled | bool | `false` |  |
 | postgresql.primary.resources.limits.cpu | int | `1` |  |

--- a/charts/bdrs-server/values.yaml
+++ b/charts/bdrs-server/values.yaml
@@ -266,6 +266,11 @@ tests:
   hookDeletePolicy: before-hook-creation,hook-succeeded
 
 postgresql:
+  image:
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    repository: bitnamilegacy/postgresql
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    tag: 15.4.0-debian-11-r45
   jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/bdrs"
   primary:
     persistence:


### PR DESCRIPTION
## WHAT

Instruct in helm charts to use the postgres image from the bitnamilegacy repository.

## WHY

The original source in the bitnami repository has been abandonned by the owner and the old images are only kept in the legacy repo untouched. For now, this is the solution to be used, but a final solution will be decided upon soon.

Closes #252
