### PR TITLE
fix: restrict duplicate bpn did mapping, composite unique key added

### DIFF
--- a/extensions/store/sql/did-entry-store-sql/src/main/resources/org/eclipse/tractusx/bdrs/sql/migration/didentry/V0_0_2__unique_did_bpn_mapping.sql
+++ b/extensions/store/sql/did-entry-store-sql/src/main/resources/org/eclipse/tractusx/bdrs/sql/migration/didentry/V0_0_2__unique_did_bpn_mapping.sql
@@ -1,1 +1,27 @@
+--
+--  * Copyright (c) 2025 Eclipse Tractus-X
+--  *
+--  * See the NOTICE file(s) distributed with this work for additional
+--  * information regarding copyright ownership.
+--  *
+--  * This program and the accompanying materials are made available under the
+--  * terms of the Apache License, Version 2.0 which is available at
+--  * https://www.apache.org/licenses/LICENSE-2.0.
+--  *
+--  * Unless required by applicable law or agreed to in writing, software
+--  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+--  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+--  * License for the specific language governing permissions and limitations
+--  * under the License.
+--  *
+--  * SPDX-License-Identifier: Apache-2.0
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+
 ALTER TABLE edc_did_entries ADD CONSTRAINT edc_did_entries_unique UNIQUE (bpn,did);
+


### PR DESCRIPTION
## WHAT
- composite unique added to restrict duplicate entries for did and BPN mapping table


Closes https://github.com/eclipse-tractusx/bpn-did-resolution-service/issues/314

