### PR TITLE
infra: change stale bot behavior

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -30,27 +30,6 @@ on:
   workflow_dispatch: # allow manual trigger
 
 jobs:
-  close-issues-in-triage:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-
-    steps:
-      - uses: actions/stale@v10
-        with:
-          operations-per-run: 1000
-          days-before-issue-stale: 32 # 4 weeks
-          days-before-issue-close: 14
-          stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 4 weeks with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
-          close-issue-reason: 'not_planned'
-          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
-          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
-          remove-issue-stale-when-updated: true
-          only-labels: 'triage'
-          repo-token: ${{ github.token }}
-
   close-issues-with-assignee:
     runs-on: ubuntu-latest
     permissions:
@@ -60,34 +39,13 @@ jobs:
         with:
           operations-per-run: 1000
           days-before-issue-stale: 32
-          days-before-issue-close: 7
+          days-before-issue-close: 10 # 10 days to ensure a preparation for the weekly phase being in the period
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 4 weeks with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          close-issue-message: "This issue was closed because it has been inactive for 10 days since being marked as stale."
           close-issue-reason: 'not_planned'
           days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
           days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
           remove-issue-stale-when-updated: true
-          exempt-issue-labels: bug,triage,later # ignore issues labelled as bug
-          repo-token: ${{ github.token }}
-
-  close-issues-without-assignee:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: actions/stale@v10
-        with:
-          operations-per-run: 1000
-          days-before-issue-stale: 14
-          days-before-issue-close: 7
-          stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 2 weeks with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
-          close-issue-reason: 'not_planned'
-          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
-          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
-          remove-issue-stale-when-updated: true
-          exempt-all-issue-assignees: true # issues with assignees will be ignored
-          exempt-issue-labels: bug,triage,later # ignore issues labelled as bug or triage
+          exempt-issue-labels: bug,later # ignore issues labelled as bug
           repo-token: ${{ github.token }}


### PR DESCRIPTION
## WHAT

- Removed stale bot handling for PRs
- Added the condition, that a later label does not trigger the stale bot

## WHY

Reasoning PR: I do not think, that it is an appropriate behavior to not accept a PR without a proper comment, it does also not happen often enough, so automatic closing of a PR is not adding a lot of value but creates potentially frustration at contributors.

Reasoning Milestones: We have long running issues, which simply do not have the priority but which need to be solved at some point. I would like to have the possibility to label them appropriately. 
