### PR TITLE
chore: Reenable upgradability tests

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -54,7 +54,6 @@ jobs:
 
   upgradeability-test:
       uses: ./.github/workflows/upgradeability-test.yaml
-      secrets: inherit
 
   # this job really serves no other purpose than waiting for the other two test workflows
   # in future iterations, this could be used as a choke point to collect test data, etc.

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -52,11 +52,9 @@ jobs:
   deployment-test:
     uses: ./.github/workflows/deployment-test.yaml
 
-# TODO: Disabled due to the postgres image change, enable again when a new release is out, there is no
-# upgradability between version 0.5.x and 0.6.x
-#  upgradeability-test:
-#      uses: ./.github/workflows/upgradeability-test.yaml
-#      secrets: inherit
+  upgradeability-test:
+      uses: ./.github/workflows/upgradeability-test.yaml
+      secrets: inherit
 
   # this job really serves no other purpose than waiting for the other two test workflows
   # in future iterations, this could be used as a choke point to collect test data, etc.


### PR DESCRIPTION
## WHAT

The disabled upgradability tests can be reenabled after the release of bdrs 0.6.0

## WHY

As the postgres image issue is gone, this should work now again

Closes #303 
