### PR TITLE
fix: publish docker image

### DIFF
--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -72,7 +72,7 @@ runs:
         ROOT_DIR: ${{ inputs.rootDir }}
         IMAGE_NAME: ${{ inputs.imagename }}
       run: |-
-        ./gradlew -p "$ROOT_DIR"/"$IMAGE_NAME" shadowJar
+        ./gradlew -p "$ROOT_DIR" shadowJar
 
     ###############################
     # Set metadata of docker image

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -23,6 +23,7 @@
 name: "Manually publish Docker images to DockerHub"
 
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       namespace:

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -32,7 +32,19 @@ on:
     paths-ignore:
       - docs/**
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish docker image"
+        required: false
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      publish:
+        description: "Publish docker image"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   # cancel older running jobs on the same branch
@@ -65,4 +77,13 @@ jobs:
     steps:
       - name: 'Master test job'
         run: echo "all test jobs have run by now"
+
+  publish-docker:
+    name: "Publish docker image"
+    needs: [ summary ]
+    permissions:
+      contents: write
+      packages: write
+    if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) && (github.event_name == 'push' || inputs.publish == true) }}
+    uses: ./.github/workflows/publish-docker.yaml
 


### PR DESCRIPTION
## WHAT

Publish Docker image after successful tests

## WHY

To always have a fresh Docker image and make it possible to run trivy based on it.
