### PR TITLE
fix: add secret to publish docker image

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -24,6 +24,21 @@ name: "Manually publish Docker images to DockerHub"
 
 on:
   workflow_call:
+    inputs:
+      namespace:
+        description: 'The namespace (=repo) in DockerHub'
+        required: false
+        type: string
+        default: "tractusx"
+      docker_tag:
+        description: 'Explicitly specify the Docker tag. Note that SHA and latest are added automatically.'
+        required: false
+        type: string
+    secrets:
+      DOCKER_HUB_USER:
+        required: false
+      DOCKER_HUB_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       namespace:

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -86,4 +86,6 @@ jobs:
       packages: write
     if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) && (github.event_name == 'push' || inputs.publish == true) }}
     uses: ./.github/workflows/publish-docker.yaml
-
+    secrets:
+      DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+      DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
## WHAT

Add a secret to publish docker image pipeline

## WHY

To always have a fresh Docker image and make it possible to run trivy based on it.
